### PR TITLE
[WIP] Only call schema values if a replacement hasn’t already been provided

### DIFF
--- a/lib/rom/factory/builder.rb
+++ b/lib/rom/factory/builder.rb
@@ -12,7 +12,11 @@ module ROM::Factory
     end
 
     def tuple(attrs)
-      input_schema.(schema.map { |k, v| [k, v.call] }.to_h.merge(attrs))
+      input_attrs = schema.each_with_object(attrs) { |(k, v), memo|
+        memo[k] = v.call unless memo.key?(k)
+      }
+
+      input_schema.(input_attrs)
     end
 
     def create(attrs = {})


### PR DESCRIPTION
This fixes an issue where a factory would generate its associations even if we explicitly provide values for them.

Pushed up a little fix to get an app of mine working, will follow up with a spec of some kind soon.