### PR TITLE
Refactor attribute and association handling

### DIFF
--- a/lib/rom/factory/attributes/association.rb
+++ b/lib/rom/factory/attributes/association.rb
@@ -1,38 +1,46 @@
 module ROM::Factory
   module Attributes
-    class Association
-      attr_reader :assoc, :builder
-
-      def initialize(assoc, builder)
-        @assoc = assoc
-        @builder = builder
+    module Association
+      def self.new(assoc, builder)
+        const_get(assoc.definition.type).new(assoc, builder)
       end
 
-      def call(attrs = {})
-        if attrs.key?(name) && !attrs.key?(foreign_key)
-          { foreign_key => attrs[name].public_send(target_key) }
-        else
-          struct = builder.persistable.create
-          tuple = { name => struct }
+      class Core
+        attr_reader :assoc, :builder
 
-          if attrs.key?(foreign_key)
-            tuple
-          else
-            tuple.merge(foreign_key => struct.public_send(target_key))
-          end
+        def initialize(assoc, builder)
+          @assoc = assoc
+          @builder = builder
+        end
+
+        def name
+          assoc.key
         end
       end
 
-      def name
-        assoc.key
-      end
+      class ManyToOne < Core
+        def call(attrs = {})
+          if attrs.key?(name) && !attrs.key?(foreign_key)
+            { foreign_key => attrs[name].public_send(target_key) }
+          else
+            struct = builder.persistable.create
+            tuple = { name => struct }
 
-      def target_key
-        assoc.target.primary_key
-      end
+            if attrs.key?(foreign_key)
+              tuple
+            else
+              tuple.merge(foreign_key => struct.public_send(target_key))
+            end
+          end
+        end
 
-      def foreign_key
-        assoc.foreign_key
+        def target_key
+          assoc.target.primary_key
+        end
+
+        def foreign_key
+          assoc.foreign_key
+        end
       end
     end
   end

--- a/lib/rom/factory/attributes/association.rb
+++ b/lib/rom/factory/attributes/association.rb
@@ -1,0 +1,39 @@
+module ROM::Factory
+  module Attributes
+    class Association
+      attr_reader :assoc, :builder
+
+      def initialize(assoc, builder)
+        @assoc = assoc
+        @builder = builder
+      end
+
+      def call(attrs = {})
+        if attrs.key?(name) && !attrs.key?(foreign_key)
+          { foreign_key => attrs[name].public_send(target_key) }
+        else
+          struct = builder.persistable.create
+          tuple = { name => struct }
+
+          if attrs.key?(foreign_key)
+            tuple
+          else
+            tuple.merge(foreign_key => struct.public_send(target_key))
+          end
+        end
+      end
+
+      def name
+        assoc.key
+      end
+
+      def target_key
+        assoc.target.primary_key
+      end
+
+      def foreign_key
+        assoc.foreign_key
+      end
+    end
+  end
+end

--- a/lib/rom/factory/attributes/callable.rb
+++ b/lib/rom/factory/attributes/callable.rb
@@ -1,19 +1,25 @@
 module ROM::Factory
   module Attributes
     class Callable
-      attr_reader :dsl, :block
+      attr_reader :name, :dsl, :block
 
-      def initialize(dsl, block)
+      def initialize(name, dsl, block)
+        @name = name
         @dsl = dsl
         @block = block
       end
 
-      def call
-        if block.is_a?(Proc)
-          dsl.instance_exec(&block)
-        else
-          block.call
-        end
+      def call(attrs)
+        return if attrs.key?(name)
+
+        result =
+          if block.is_a?(Proc)
+            dsl.instance_exec(&block)
+          else
+            block.call
+          end
+
+        { name => result }
       end
     end
   end

--- a/lib/rom/factory/attributes/regular.rb
+++ b/lib/rom/factory/attributes/regular.rb
@@ -1,12 +1,17 @@
 module ROM::Factory
   module Attributes
     class Regular
-      def initialize(value)
+      attr_reader :name, :value
+
+      def initialize(name, value)
+        @name = name
         @value = value
       end
 
-      def call
-        @value
+      def call(attrs = {})
+        return if attrs.key?(name)
+
+        { name => value }
       end
     end
   end

--- a/lib/rom/factory/attributes/sequence.rb
+++ b/lib/rom/factory/attributes/sequence.rb
@@ -1,13 +1,17 @@
 module ROM::Factory
   module Attributes
     class Sequence
-      def initialize(&block)
+      attr_reader :name, :count, :block
+
+      def initialize(name, &block)
+        @name = name
         @count = 0
         @block = block
       end
 
-      def call
-        @block.call(increment)
+      def call(attrs = {})
+        return if attrs.key?(name)
+        block.call(increment)
       end
 
       def increment

--- a/lib/rom/factory/builder.rb
+++ b/lib/rom/factory/builder.rb
@@ -2,17 +2,17 @@ require 'delegate'
 
 module ROM::Factory
   class Builder
-    attr_reader :schema, :relation, :model
+    attr_reader :attributes, :relation, :model
 
-    def initialize(schema, relation)
-      @schema = schema
+    def initialize(attributes, relation)
+      @attributes = attributes
       @relation = relation.with(auto_map: true, auto_struct: true)
       @model = @relation.combine(*assoc_names).mapper.model
       @sequence = 0
     end
 
     def assoc_names
-      schema.keys.select { |key| schema[key].is_a?(Attributes::Association::Core) }
+      attributes.select { |attr| attr.is_a?(Attributes::Association::Core) }.map(&:name)
     end
 
     def tuple(attrs)
@@ -42,7 +42,7 @@ module ROM::Factory
     end
 
     def default_attrs(attrs)
-      schema.values.map { |attr| attr.(attrs) }.compact.reduce(:merge)
+      attributes.map { |attr| attr.(attrs) }.compact.reduce(:merge)
     end
 
     def struct_attrs

--- a/lib/rom/factory/builder.rb
+++ b/lib/rom/factory/builder.rb
@@ -12,7 +12,7 @@ module ROM::Factory
     end
 
     def assoc_names
-      schema.keys.select { |key| schema[key].is_a?(Attributes::Association) }
+      schema.keys.select { |key| schema[key].is_a?(Attributes::Association::Core) }
     end
 
     def tuple(attrs)

--- a/lib/rom/factory/dsl.rb
+++ b/lib/rom/factory/dsl.rb
@@ -5,6 +5,7 @@ require 'rom/factory/builder'
 require 'rom/factory/attributes/regular'
 require 'rom/factory/attributes/callable'
 require 'rom/factory/attributes/sequence'
+require 'rom/factory/attributes/association'
 
 module ROM
   module Factory
@@ -58,14 +59,9 @@ module ROM
 
       def association(name)
         assoc = _relation.associations[name]
-        other = assoc.target
+        builder = _factories.registry[name]
 
-        fk = assoc.foreign_key
-        pk = other.primary_key
-
-        block = -> { create(name)[pk] }
-
-        _schema[fk] = attributes::Callable.new(self, block)
+        _schema[name] = attributes::Association.new(assoc, builder)
       end
 
       private
@@ -83,14 +79,14 @@ module ROM
       end
 
       def define_sequence(name, block)
-        _schema[name] = attributes::Callable.new(self, attributes::Sequence.new(&block))
+        _schema[name] = attributes::Callable.new(name, self, attributes::Sequence.new(name, &block))
       end
 
       def define_attr(name, *args, &block)
         if block
-          _schema[name] = attributes::Callable.new(self, block)
+          _schema[name] = attributes::Callable.new(name, self, block)
         else
-          _schema[name] = attributes::Regular.new(*args)
+          _schema[name] = attributes::Regular.new(name, *args)
         end
       end
 

--- a/lib/rom/factory/dsl.rb
+++ b/lib/rom/factory/dsl.rb
@@ -23,19 +23,19 @@ module ROM
     class DSL < BasicObject
       define_method(:rand, ::Kernel.instance_method(:rand))
 
-      attr_reader :_name, :_relation, :_schema, :_factories, :_valid_names
+      attr_reader :_name, :_relation, :_attributes, :_factories, :_valid_names
 
-      def initialize(name, schema: {}, relation:, factories:, &block)
+      def initialize(name, attributes: [], relation:, factories:, &block)
         @_name = name
         @_relation = relation
         @_factories = factories
-        @_schema = schema.dup
+        @_attributes = attributes.dup
         @_valid_names = _relation.schema.attributes.map(&:name)
         yield(self)
       end
 
       def call
-        ::ROM::Factory::Builder.new(_schema, _relation)
+        ::ROM::Factory::Builder.new(_attributes, _relation)
       end
 
       def create(name, *args)
@@ -61,7 +61,7 @@ module ROM
         assoc = _relation.associations[name]
         builder = _factories.registry[name]
 
-        _schema[name] = attributes::Association.new(assoc, builder)
+        _attributes << attributes::Association.new(assoc, builder)
       end
 
       private
@@ -79,14 +79,14 @@ module ROM
       end
 
       def define_sequence(name, block)
-        _schema[name] = attributes::Callable.new(name, self, attributes::Sequence.new(name, &block))
+        _attributes << attributes::Callable.new(name, self, attributes::Sequence.new(name, &block))
       end
 
       def define_attr(name, *args, &block)
         if block
-          _schema[name] = attributes::Callable.new(name, self, block)
+          _attributes << attributes::Callable.new(name, self, block)
         else
-          _schema[name] = attributes::Regular.new(name, *args)
+          _attributes << attributes::Regular.new(name, *args)
         end
       end
 

--- a/lib/rom/factory/factories.rb
+++ b/lib/rom/factory/factories.rb
@@ -57,7 +57,7 @@ module ROM::Factory
       end
 
       def extend_builder(name, parent, &block)
-        DSL.new(name, schema: parent.schema, relation: parent.relation, factories: self, &block).call
+        DSL.new(name, attributes: parent.attributes, relation: parent.relation, factories: self, &block).call
       end
 
       def [](name, attrs = {})

--- a/spec/integration/rom/factory_spec.rb
+++ b/spec/integration/rom/factory_spec.rb
@@ -319,7 +319,6 @@ RSpec.describe ROM::Factory do
         f.title 'A task'
         f.association(:user)
       end
-
     end
 
     it 'exposes create method in callable attribute blocks' do

--- a/spec/unit/rom/builder_spec.rb
+++ b/spec/unit/rom/builder_spec.rb
@@ -1,0 +1,69 @@
+require 'rom/factory/builder'
+
+RSpec.describe ROM::Factory::Builder do
+  subject(:builder) { ROM::Factory::Builder.new(schema, relation) }
+
+  include_context 'database'
+
+  let(:factories) do
+    ROM::Factory.configure do |config|
+      config.rom = rom
+    end
+  end
+
+  describe 'belongs_to association' do
+    let(:schema) do
+      {
+        title: ROM::Factory::Attributes::Regular.new(:title, 'To-do'),
+        user: ROM::Factory::Attributes::Association.new(tasks.associations[:user], factories.registry[:user])
+      }
+    end
+
+    let(:tasks) { relations[:tasks] }
+    let(:users) { relations[:users] }
+    let(:relation) { tasks }
+
+    before do
+      conn.create_table(:users) do
+        primary_key :id
+        column :name, String
+      end
+
+      conn.create_table(:tasks) do
+        primary_key :id
+        foreign_key :user_id, :users
+        column :title, String, null: false
+      end
+
+      conf.relation(:tasks) do
+        schema(infer: true) do
+          associations do
+            belongs_to :user
+          end
+        end
+      end
+
+      conf.relation(:users) do
+        schema(infer: true)
+      end
+
+      factories.define(:user) do |f|
+        f.name 'Jane'
+      end
+    end
+
+    after do
+      conn.drop_table(:tasks)
+      conn.drop_table(:users)
+    end
+
+    describe '#create' do
+      it 'builds associated struct' do
+        task = builder.create
+
+        expect(task.title).to eql('To-do')
+        expect(task.user.name).to eql('Jane')
+      end
+    end
+  end
+end

--- a/spec/unit/rom/builder_spec.rb
+++ b/spec/unit/rom/builder_spec.rb
@@ -1,7 +1,7 @@
 require 'rom/factory/builder'
 
 RSpec.describe ROM::Factory::Builder do
-  subject(:builder) { ROM::Factory::Builder.new(schema, relation) }
+  subject(:builder) { ROM::Factory::Builder.new(attributes, relation) }
 
   include_context 'database'
 
@@ -12,11 +12,9 @@ RSpec.describe ROM::Factory::Builder do
   end
 
   describe 'belongs_to association' do
-    let(:schema) do
-      {
-        title: ROM::Factory::Attributes::Regular.new(:title, 'To-do'),
-        user: ROM::Factory::Attributes::Association.new(tasks.associations[:user], factories.registry[:user])
-      }
+    let(:attributes) do
+      [ROM::Factory::Attributes::Regular.new(:title, 'To-do'),
+       ROM::Factory::Attributes::Association.new(tasks.associations[:user], factories.registry[:user])]
     end
 
     let(:tasks) { relations[:tasks] }


### PR DESCRIPTION
This is a refactor which changes the way attributes are handled. We're no longer using a schema represented by `{ name => attr_object }`, instead we simply have an array with attributes. They have explicit names and encapsulate behavior. On top of this, `Associations::*` attribute types were added, and previous implementation of `belongs_to` support was refactored to use this. It means that we can now easily add remaining associations.