### PR TITLE
Dependant attributes

### DIFF
--- a/lib/rom/factory/attribute_registry.rb
+++ b/lib/rom/factory/attribute_registry.rb
@@ -38,7 +38,7 @@ module ROM
       end
 
       def tsort_each_child(attr, &block)
-        attr.dependency_names.map { |name| self[name] }.each(&block)
+        attr.dependency_names.map { |name| self[name] }.compact.each(&block)
       end
     end
   end

--- a/lib/rom/factory/attribute_registry.rb
+++ b/lib/rom/factory/attribute_registry.rb
@@ -1,0 +1,45 @@
+require 'tsort'
+
+module ROM
+  module Factory
+    class AttributeRegistry
+      include Enumerable
+      include TSort
+
+      attr_reader :elements
+
+      def initialize(elements = [])
+        @elements = elements
+      end
+
+      def each(&block)
+        elements.each(&block)
+      end
+
+      def [](name)
+        detect { |e| e.name.equal?(name) }
+      end
+
+      def <<(element)
+        existing = self[element.name]
+        elements.delete(existing) if existing
+        elements << element
+        self
+      end
+
+      def dup
+        self.class.new(elements.dup)
+      end
+
+      private
+
+      def tsort_each_node(&block)
+        each(&block)
+      end
+
+      def tsort_each_child(attr, &block)
+        attr.dependency_names.map { |name| self[name] }.each(&block)
+      end
+    end
+  end
+end

--- a/lib/rom/factory/attributes/association.rb
+++ b/lib/rom/factory/attributes/association.rb
@@ -16,6 +16,10 @@ module ROM::Factory
         def name
           assoc.key
         end
+
+        def dependency_names
+          []
+        end
       end
 
       class ManyToOne < Core

--- a/lib/rom/factory/attributes/callable.rb
+++ b/lib/rom/factory/attributes/callable.rb
@@ -3,7 +3,7 @@ module ROM::Factory
     class Callable
       attr_reader :name, :dsl, :block
 
-      def initialize(name, dsl, block)
+      def initialize(name, dsl = nil, &block)
         @name = name
         @dsl = dsl
         @block = block
@@ -20,6 +20,14 @@ module ROM::Factory
           end
 
         { name => result }
+      end
+
+      def dependency?(other)
+        dependency_names.include?(other.name)
+      end
+
+      def dependency_names
+        block.parameters.map(&:last)
       end
     end
   end

--- a/lib/rom/factory/attributes/callable.rb
+++ b/lib/rom/factory/attributes/callable.rb
@@ -9,12 +9,12 @@ module ROM::Factory
         @block = block
       end
 
-      def call(attrs)
+      def call(attrs, *args)
         return if attrs.key?(name)
 
         result =
           if block.is_a?(Proc)
-            dsl.instance_exec(&block)
+            dsl.instance_exec(*args, &block)
           else
             block.call
           end

--- a/lib/rom/factory/attributes/regular.rb
+++ b/lib/rom/factory/attributes/regular.rb
@@ -13,6 +13,14 @@ module ROM::Factory
 
         { name => value }
       end
+
+      def dependency?(*)
+        false
+      end
+
+      def dependency_names
+        []
+      end
     end
   end
 end

--- a/lib/rom/factory/attributes/sequence.rb
+++ b/lib/rom/factory/attributes/sequence.rb
@@ -14,6 +14,10 @@ module ROM::Factory
         block.call(increment)
       end
 
+      def to_proc
+        method(:call).to_proc
+      end
+
       def increment
         @count += 1
       end

--- a/lib/rom/factory/attributes/sequence.rb
+++ b/lib/rom/factory/attributes/sequence.rb
@@ -21,6 +21,10 @@ module ROM::Factory
       def increment
         @count += 1
       end
+
+      def dependency_names
+        []
+      end
     end
   end
 end

--- a/lib/rom/factory/builder.rb
+++ b/lib/rom/factory/builder.rb
@@ -42,7 +42,14 @@ module ROM::Factory
     end
 
     def default_attrs(attrs)
-      attributes.map { |attr| attr.(attrs) }.compact.reduce(:merge)
+      attributes.tsort.each_with_object({}) do |attr, h|
+        deps = attr.dependency_names.map { |k| h[k] }.compact
+        result = attr.(attrs, *deps)
+
+        if result
+          h.update(result)
+        end
+      end
     end
 
     def struct_attrs

--- a/lib/rom/factory/dsl.rb
+++ b/lib/rom/factory/dsl.rb
@@ -2,6 +2,7 @@ require 'faker'
 require 'dry/core/inflector'
 
 require 'rom/factory/builder'
+require 'rom/factory/attribute_registry'
 require 'rom/factory/attributes/regular'
 require 'rom/factory/attributes/callable'
 require 'rom/factory/attributes/sequence'
@@ -25,7 +26,7 @@ module ROM
 
       attr_reader :_name, :_relation, :_attributes, :_factories, :_valid_names
 
-      def initialize(name, attributes: [], relation:, factories:, &block)
+      def initialize(name, attributes: AttributeRegistry.new, relation:, factories:, &block)
         @_name = name
         @_relation = relation
         @_factories = factories
@@ -79,12 +80,12 @@ module ROM
       end
 
       def define_sequence(name, block)
-        _attributes << attributes::Callable.new(name, self, attributes::Sequence.new(name, &block))
+        _attributes << attributes::Callable.new(name, self, &attributes::Sequence.new(name, &block))
       end
 
       def define_attr(name, *args, &block)
         if block
-          _attributes << attributes::Callable.new(name, self, block)
+          _attributes << attributes::Callable.new(name, self, &block)
         else
           _attributes << attributes::Regular.new(name, *args)
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,5 +52,5 @@ Warning.extend(SileneceWarnings) if warning_api_available
 
 RSpec.configure do |config|
   config.disable_monkey_patching!
-  config.warnings = warning_api_available
+  # config.warnings = warning_api_available
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,9 +48,16 @@ module SileneceWarnings
   end
 end
 
+module Helpers
+  def attribute(type, name, *args, &block)
+    ROM::Factory::Attributes.const_get(type).new(name, *args, &block)
+  end
+end
+
 Warning.extend(SileneceWarnings) if warning_api_available
 
 RSpec.configure do |config|
   config.disable_monkey_patching!
+  config.include(Helpers)
   # config.warnings = warning_api_available
 end

--- a/spec/unit/rom/attribute_registry_spec.rb
+++ b/spec/unit/rom/attribute_registry_spec.rb
@@ -3,10 +3,6 @@ require 'rom/factory/attribute_registry'
 RSpec.describe ROM::Factory::AttributeRegistry do
   subject(:registry) { ROM::Factory::AttributeRegistry.new(elements) }
 
-  def attribute(type, name, *args, &block)
-    ROM::Factory::Attributes.const_get(type).new(name, *args, &block)
-  end
-
   let(:elements) do
     [email_attr, name_attr]
   end

--- a/spec/unit/rom/attribute_registry_spec.rb
+++ b/spec/unit/rom/attribute_registry_spec.rb
@@ -1,0 +1,27 @@
+require 'rom/factory/attribute_registry'
+
+RSpec.describe ROM::Factory::AttributeRegistry do
+  subject(:registry) { ROM::Factory::AttributeRegistry.new(elements) }
+
+  def attribute(type, name, *args, &block)
+    ROM::Factory::Attributes.const_get(type).new(name, *args, &block)
+  end
+
+  let(:elements) do
+    [email_attr, name_attr]
+  end
+
+  let(:name_attr) do
+    attribute(:Regular, :name, 'Jane')
+  end
+
+  let(:email_attr) do
+    attribute(:Callable, :email) { |name| "#{name}@rom-rb.org" }
+  end
+
+  describe '#tsort' do
+    it 'sorts attributes by their dependencies' do
+      expect(registry.tsort).to eql([name_attr, email_attr])
+    end
+  end
+end

--- a/spec/unit/rom/builder_spec.rb
+++ b/spec/unit/rom/builder_spec.rb
@@ -1,13 +1,45 @@
 require 'rom/factory/builder'
 
 RSpec.describe ROM::Factory::Builder do
-  subject(:builder) { ROM::Factory::Builder.new(attributes, relation) }
+  subject(:builder) { ROM::Factory::Builder.new(ROM::Factory::AttributeRegistry.new(attributes), relation) }
 
   include_context 'database'
 
   let(:factories) do
     ROM::Factory.configure do |config|
       config.rom = rom
+    end
+  end
+
+  describe 'dependant attributes' do
+    let(:attributes) do
+      [attribute(:Callable, :email) { |name| "#{name.downcase}@rom-rb.org" },
+       attribute(:Regular, :name, 'Jane')]
+    end
+
+    let(:relation) { relations[:users] }
+
+    before do
+      conn.create_table(:users) do
+        primary_key :id
+        column :name, String
+        column :email, String
+      end
+
+      conf.relation(:users) do
+        schema(infer: true)
+      end
+    end
+
+    after do
+      conn.drop_table(:users)
+    end
+
+    it 'evaluates attributes in correct order' do
+      user = builder.create
+
+      expect(user.name).to eql('Jane')
+      expect(user.email).to eql('jane@rom-rb.org')
     end
   end
 

--- a/spec/unit/rom/builder_spec.rb
+++ b/spec/unit/rom/builder_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe ROM::Factory::Builder do
 
   describe 'belongs_to association' do
     let(:attributes) do
-      [ROM::Factory::Attributes::Regular.new(:title, 'To-do'),
-       ROM::Factory::Attributes::Association.new(tasks.associations[:user], factories.registry[:user])]
+      [attribute(:Regular, :title, 'To-do'),
+       attribute(:Association, tasks.associations[:user], factories.registry[:user])]
     end
 
     let(:tasks) { relations[:tasks] }


### PR DESCRIPTION
This adds `AttributeRegistry` which can be tsorted based on attribute dependencies, which allows syntax like this:

``` ruby
Factory.define(:user) do |f|
  f.name "Jane"
  f.email { |name| "#{name.downcase}@rom-rb.org" }
end
```

Associations will use this too, but that's another PR.