### PR TITLE
Support for has_many and has_one associations

### DIFF
--- a/lib/rom/factory/attribute_registry.rb
+++ b/lib/rom/factory/attribute_registry.rb
@@ -31,6 +31,14 @@ module ROM
         self.class.new(elements.dup)
       end
 
+      def values
+        self.class.new(elements.select(&:value?))
+      end
+
+      def associations
+        self.class.new(elements.select { |e| e.kind_of?(Attributes::Association::Core) })
+      end
+
       private
 
       def tsort_each_node(&block)

--- a/lib/rom/factory/attributes/association.rb
+++ b/lib/rom/factory/attributes/association.rb
@@ -87,6 +87,16 @@ module ROM::Factory
           assoc.foreign_key
         end
       end
+
+      class OneToOne < OneToMany
+        def call(attrs = {}, parent)
+          return if attrs.key?(name)
+
+          struct = builder.persistable.create(foreign_key => parent[source_key])
+
+          { name => struct }
+        end
+      end
     end
   end
 end

--- a/lib/rom/factory/attributes/association.rb
+++ b/lib/rom/factory/attributes/association.rb
@@ -1,20 +1,33 @@
 module ROM::Factory
   module Attributes
     module Association
-      def self.new(assoc, builder)
-        const_get(assoc.definition.type).new(assoc, builder)
+      def self.new(assoc, builder, options = {})
+        const_get(assoc.definition.type).new(assoc, builder, options)
       end
 
       class Core
-        attr_reader :assoc, :builder
+        attr_reader :assoc, :options
 
-        def initialize(assoc, builder)
+        def initialize(assoc, builder, options = {})
           @assoc = assoc
-          @builder = builder
+          @builder_proc = builder
+          @options = options
+        end
+
+        def builder
+          @__builder__ ||= @builder_proc.()
         end
 
         def name
           assoc.key
+        end
+
+        def dependency?(*)
+          false
+        end
+
+        def value?
+          false
         end
 
         def dependency_names
@@ -40,6 +53,34 @@ module ROM::Factory
 
         def target_key
           assoc.target.primary_key
+        end
+
+        def foreign_key
+          assoc.foreign_key
+        end
+      end
+
+      class OneToMany < Core
+        def call(attrs = {}, parent)
+          return if attrs.key?(name)
+
+          structs = count.times.map {
+            builder.persistable.create(foreign_key => parent[source_key])
+          }
+
+          { name => structs }
+        end
+
+        def dependency?(rel)
+          assoc.source == rel
+        end
+
+        def count
+          options.fetch(:count)
+        end
+
+        def source_key
+          assoc.source.primary_key
         end
 
         def foreign_key

--- a/lib/rom/factory/attributes/callable.rb
+++ b/lib/rom/factory/attributes/callable.rb
@@ -22,6 +22,10 @@ module ROM::Factory
         { name => result }
       end
 
+      def value?
+        true
+      end
+
       def dependency?(other)
         dependency_names.include?(other.name)
       end

--- a/lib/rom/factory/attributes/regular.rb
+++ b/lib/rom/factory/attributes/regular.rb
@@ -14,6 +14,10 @@ module ROM::Factory
         { name => value }
       end
 
+      def value?
+        true
+      end
+
       def dependency?(*)
         false
       end

--- a/lib/rom/factory/attributes/sequence.rb
+++ b/lib/rom/factory/attributes/sequence.rb
@@ -22,6 +22,10 @@ module ROM::Factory
         @count += 1
       end
 
+      def value?
+        true
+      end
+
       def dependency_names
         []
       end

--- a/lib/rom/factory/dsl.rb
+++ b/lib/rom/factory/dsl.rb
@@ -58,11 +58,11 @@ module ROM
         ::ROM::Factory.fake(*args)
       end
 
-      def association(name)
+      def association(name, options = {})
         assoc = _relation.associations[name]
-        builder = _factories.registry[name]
+        builder = -> { _factories.for_relation(assoc.target) }
 
-        _attributes << attributes::Association.new(assoc, builder)
+        _attributes << attributes::Association.new(assoc, builder, options)
       end
 
       private

--- a/lib/rom/factory/factories.rb
+++ b/lib/rom/factory/factories.rb
@@ -52,6 +52,14 @@ module ROM::Factory
         registry[name] = builder
       end
 
+      def for_relation(relation)
+        registry.fetch(infer_factory_name(relation.name.to_sym))
+      end
+
+      def infer_factory_name(name)
+        ::Dry::Core::Inflector.singularize(name).to_sym
+      end
+
       def infer_relation(name)
         ::Dry::Core::Inflector.pluralize(name).to_sym
       end


### PR DESCRIPTION
This adds support for `has_many` and `has_one`. I ended up **not** using dependent attributes as it's a bit more complex, since we need to postpone persisting child tuples until parent is persisted.