### PR TITLE
Raise an exception when trying to access a factory that hasn't been defined

### DIFF
--- a/lib/rom/factory/constants.rb
+++ b/lib/rom/factory/constants.rb
@@ -1,0 +1,9 @@
+module ROM
+  module Factory
+    class FactoryNotDefinedError < StandardError
+      def initialize(name)
+        super("Factory +#{name}+ not defined")
+      end
+    end
+  end
+end

--- a/lib/rom/factory/factories.rb
+++ b/lib/rom/factory/factories.rb
@@ -4,6 +4,7 @@ require 'dry/core/inflector'
 require 'rom/initializer'
 require 'rom/struct'
 require 'rom/factory/dsl'
+require 'rom/factory/registry'
 
 module ROM::Factory
   # In-memory builder API
@@ -62,7 +63,7 @@ module ROM::Factory
 
     # @!attribute [r] registry
     #   @return [Hash<Symbol=>Builder>] a map with defined db-backed builders
-    option :registry, default: proc { Hash.new }
+    option :registry, default: proc { Registry.new }
 
     # Define a new builder
     #
@@ -195,7 +196,7 @@ module ROM::Factory
 
     # @api private
     def for_relation(relation)
-      registry.fetch(infer_factory_name(relation.name.to_sym))
+      registry[infer_factory_name(relation.name.to_sym)]
     end
 
     # @api private

--- a/lib/rom/factory/registry.rb
+++ b/lib/rom/factory/registry.rb
@@ -1,0 +1,34 @@
+require 'rom/factory/constants'
+
+module ROM
+  module Factory
+    # @api private
+    class Registry
+      # @!attribute [r] elements
+      #   @return [Hash] a hash with factory builders
+      attr_reader :elements
+
+      # @api private
+      def initialize
+        @elements = {}
+      end
+
+      # @api private
+      def key?(name)
+        elements.key?(name)
+      end
+
+      # @api private
+      def []=(name, builder)
+        elements[name] = builder
+      end
+
+      # @api private
+      def [](name)
+        elements.fetch(name) do
+          raise FactoryNotDefinedError.new(name)
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/rom/factory_spec.rb
+++ b/spec/integration/rom/factory_spec.rb
@@ -7,6 +7,20 @@ RSpec.describe ROM::Factory do
     end
   end
 
+  describe 'factory is not defined' do
+    it 'raises error for persistable' do
+      expect {
+        factories[:not_defined]
+      }.to raise_error(ROM::Factory::FactoryNotDefinedError)
+    end
+
+    it 'raises error for structs' do
+      expect {
+        factories.structs[:not_defined]
+      }.to raise_error(ROM::Factory::FactoryNotDefinedError)
+    end
+  end
+
   describe '.structs' do
     it 'returns a plain struct builder' do
       factories.define(:user) do |f|


### PR DESCRIPTION


Solves #3 

@solnic I went with the option of creating this `Registry` to avoid having to raise the same error in multiple places. Maybe it is a little over kill we can always return to raising the exception in the two places that we access the registry.