### PR TITLE
Struct namespace support

### DIFF
--- a/lib/rom/factory.rb
+++ b/lib/rom/factory.rb
@@ -21,9 +21,11 @@ module ROM
     #
     # @api public
     def self.configure(name = DEFAULT_NAME, &block)
-      Dry::Core::ClassBuilder.new(name: name, parent: Factories).call do |klass|
+      klass = Dry::Core::ClassBuilder.new(name: name, parent: Factories).call do |klass|
         klass.configure(&block)
       end
+
+      klass.new(klass.config.rom)
     end
   end
 end

--- a/lib/rom/factory/builder.rb
+++ b/lib/rom/factory/builder.rb
@@ -1,5 +1,6 @@
 require 'dry/core/constants'
 
+require 'rom/struct'
 require 'rom/factory/tuple_evaluator'
 require 'rom/factory/builder/persistable'
 
@@ -32,8 +33,8 @@ module ROM::Factory
     alias_method :create, :struct
 
     # @api private
-    def persistable
-      Persistable.new(self)
+    def persistable(struct_namespace = ROM::Struct)
+      Persistable.new(self, relation.struct_namespace(struct_namespace))
     end
 
     # @api private

--- a/lib/rom/factory/builder.rb
+++ b/lib/rom/factory/builder.rb
@@ -1,25 +1,24 @@
 require 'dry/core/constants'
 
 require 'rom/struct'
+require 'rom/initializer'
 require 'rom/factory/tuple_evaluator'
 require 'rom/factory/builder/persistable'
 
 module ROM::Factory
   # @api private
   class Builder
+    extend ROM::Initializer
+
     include Dry::Core::Constants
 
-    # @api private
-    attr_reader :attributes
+    # @!attribute [r] attributes
+    #   @return [ROM::Factory::Attributes]
+    param :attributes
 
-    # @api private
-    attr_reader :tuple_evaluator
-
-    # @api private
-    def initialize(attributes, relation)
-      @attributes = attributes
-      @tuple_evaluator = TupleEvaluator.new(attributes, relation)
-    end
+    # @!attribute [r] relation
+    #   @return [ROM::Relation]
+    option :relation, reader: false
 
     # @api private
     def tuple(attrs = EMPTY_HASH)
@@ -33,8 +32,18 @@ module ROM::Factory
     alias_method :create, :struct
 
     # @api private
+    def struct_namespace(namespace)
+      with(relation: relation.struct_namespace(namespace))
+    end
+
+    # @api private
     def persistable(struct_namespace = ROM::Struct)
       Persistable.new(self, relation.struct_namespace(struct_namespace))
+    end
+
+    # @api private
+    def tuple_evaluator
+      @__tuple_evaluator__ ||= TupleEvaluator.new(attributes, options[:relation])
     end
 
     # @api private

--- a/lib/rom/factory/dsl.rb
+++ b/lib/rom/factory/dsl.rb
@@ -39,7 +39,7 @@ module ROM
 
       # @api private
       def call
-        ::ROM::Factory::Builder.new(_attributes, _relation)
+        ::ROM::Factory::Builder.new(_attributes, relation: _relation)
       end
 
       # Delegate to a builder and persist a struct

--- a/lib/rom/factory/factories.rb
+++ b/lib/rom/factory/factories.rb
@@ -1,6 +1,7 @@
 require 'dry/configurable'
 require 'dry/core/inflector'
 
+require 'rom/initializer'
 require 'rom/factory/dsl'
 
 module ROM::Factory
@@ -41,144 +42,139 @@ module ROM::Factory
   # @api public
   class Factories
     extend Dry::Configurable
+    extend ROM::Initializer
 
     setting :rom
 
-    class << self
-      # @!attribute [r] registry
-      #   @return [Hash<Symbol=>Builder>]
-      attr_reader :registry
+    # @!attribute [r] rom
+    #   @return [ROM::Container] configured rom container
+    param :rom
 
-      # @!attribute [r] structs
-      #   @return [Structs] In-memory struct builder instance
-      attr_reader :structs
+    # @!attribute [r] registry
+    #   @return [Hash<Symbol=>Builder>] a map with defined db-backed builders
+    option :registry, default: proc { Hash.new }
 
-      # @api private
-      def inherited(klass)
-        registry = {}
-        klass.instance_variable_set(:'@registry', registry)
-        klass.instance_variable_set(:'@structs', Structs.new(registry))
-        super
+    # @!attribute [r] structs
+    #   @return [Structs] in-memory struct builder instance
+    option :structs, optional: true, default: proc { Structs.new(registry) }
+
+    # Define a new builder
+    #
+    # @example a simple builder
+    #   MyFactory.define(:user) do |f|
+    #     f.name "Jane"
+    #     f.email "jane@doe.org"
+    #   end
+    #
+    # @example a builder using auto-generated fake values
+    #   MyFactory.define(:user) do |f|
+    #     f.name { fake(:name) }
+    #     f.email { fake(:internet, :email) }
+    #   end
+    #
+    # @example a builder using sequenced values
+    #   MyFactory.define(:user) do |f|
+    #     f.sequence(:name) { |n| "user-#{n}" }
+    #   end
+    #
+    # @example a builder using values from other attribute(s)
+    #   MyFactory.define(:user) do |f|
+    #     f.name "Jane"
+    #     f.email { |name| "#{name.downcase}@rom-rb.org" }
+    #   end
+    #
+    # @example a builder with "belongs-to" association
+    #   MyFactory.define(:group) do |f|
+    #     f.name "Admins"
+    #   end
+    #
+    #   MyFactory.define(:user) do |f|
+    #     f.name "Jane"
+    #     f.association(:group)
+    #   end
+    #
+    # @example a builder with "has-many" association
+    #   MyFactory.define(:group) do |f|
+    #     f.name "Admins"
+    #     f.association(:users, count: 2)
+    #   end
+    #
+    #   MyFactory.define(:user) do |f|
+    #     f.sequence(:name) { |n| "user-#{n}" }
+    #   end
+    #
+    # @example a builder which extends another builder
+    #   MyFactory.define(:user) do |f|
+    #     f.name "Jane"
+    #     f.admin false
+    #   end
+    #
+    #   MyFactory.define(admin: :user) do |f|
+    #     f.admin true
+    #   end
+    #
+    # @param [Symbol, Hash<Symbol=>Symbol>] spec Builder identifier, can point to a parent builder too
+    # @param [Hash] opts Additional options
+    # @option opts [Symbol] relation An optional relation name (defaults to pluralized builder name)
+    #
+    # @return [ROM::Factory::Builder]
+    #
+    # @api public
+    def define(spec, **opts, &block)
+      name, parent = spec.is_a?(Hash) ? spec.flatten(1) : spec
+
+      if registry.key?(name)
+        raise ArgumentError, "#{name.inspect} factory has been already defined"
       end
 
-      # Define a new builder
-      #
-      # @example a simple builder
-      #   MyFactory.define(:user) do |f|
-      #     f.name "Jane"
-      #     f.email "jane@doe.org"
-      #   end
-      #
-      # @example a builder using auto-generated fake values
-      #   MyFactory.define(:user) do |f|
-      #     f.name { fake(:name) }
-      #     f.email { fake(:internet, :email) }
-      #   end
-      #
-      # @example a builder using sequenced values
-      #   MyFactory.define(:user) do |f|
-      #     f.sequence(:name) { |n| "user-#{n}" }
-      #   end
-      #
-      # @example a builder using values from other attribute(s)
-      #   MyFactory.define(:user) do |f|
-      #     f.name "Jane"
-      #     f.email { |name| "#{name.downcase}@rom-rb.org" }
-      #   end
-      #
-      # @example a builder with "belongs-to" association
-      #   MyFactory.define(:group) do |f|
-      #     f.name "Admins"
-      #   end
-      #
-      #   MyFactory.define(:user) do |f|
-      #     f.name "Jane"
-      #     f.association(:group)
-      #   end
-      #
-      # @example a builder with "has-many" association
-      #   MyFactory.define(:group) do |f|
-      #     f.name "Admins"
-      #     f.association(:users, count: 2)
-      #   end
-      #
-      #   MyFactory.define(:user) do |f|
-      #     f.sequence(:name) { |n| "user-#{n}" }
-      #   end
-      #
-      # @example a builder which extends another builder
-      #   MyFactory.define(:user) do |f|
-      #     f.name "Jane"
-      #     f.admin false
-      #   end
-      #
-      #   MyFactory.define(admin: :user) do |f|
-      #     f.admin true
-      #   end
-      #
-      # @param [Symbol, Hash<Symbol=>Symbol>] spec Builder identifier, can point to a parent builder too
-      # @param [Hash] opts Additional options
-      # @option opts [Symbol] relation An optional relation name (defaults to pluralized builder name)
-      #
-      # @return [ROM::Factory::Builder]
-      #
-      # @api public
-      def define(spec, **opts, &block)
-        name, parent = spec.is_a?(Hash) ? spec.flatten(1) : spec
-
-        if registry.key?(name)
-          raise ArgumentError, "#{name.inspect} factory has been already defined"
+      builder =
+        if parent
+          extend_builder(name, registry[parent], &block)
+        else
+          relation_name = opts.fetch(:relation) { infer_relation(name) }
+          relation = rom.relations[relation_name]
+          DSL.new(name, relation: relation, factories: self, &block).call
         end
 
-        builder =
-          if parent
-            extend_builder(name, registry[parent], &block)
-          else
-            relation_name = opts.fetch(:relation) { infer_relation(name) }
-            relation = config.rom.relations[relation_name]
-            DSL.new(name, relation: relation, factories: self, &block).call
-          end
+      registry[name] = builder
+    end
 
-        registry[name] = builder
-      end
+    # Create and persist a new struct
+    #
+    # @example create a struct with default attributes
+    #   MyFactory[:user]
+    #
+    # @example create a struct with some attributes overridden
+    #   MyFactory[:user, name: "Jane"]
+    #
+    # @param [Symbol] name The name of the registered factory
+    # @param [Hash] attrs An optional hash with attributes
+    #
+    # @return [ROM::Struct]
+    #
+    # @api public
+    def [](name, attrs = {})
+      registry[name].persistable.create(attrs)
+    end
 
-      # Create and persist a new struct
-      #
-      # @example create a struct with default attributes
-      #   MyFactory[:user]
-      #
-      # @example create a struct with some attributes overridden
-      #   MyFactory[:user, name: "Jane"]
-      #
-      # @param [Symbol] name The name of the registered factory
-      # @param [Hash] attrs An optional hash with attributes
-      #
-      # @return [ROM::Struct]
-      #
-      # @api public
-      def [](name, attrs = {})
-        registry[name].persistable.create(attrs)
-      end
+    # @api private
+    def for_relation(relation)
+      registry.fetch(infer_factory_name(relation.name.to_sym))
+    end
 
-      # @api private
-      def for_relation(relation)
-        registry.fetch(infer_factory_name(relation.name.to_sym))
-      end
+    # @api private
+    def infer_factory_name(name)
+      ::Dry::Core::Inflector.singularize(name).to_sym
+    end
 
-      # @api private
-      def infer_factory_name(name)
-        ::Dry::Core::Inflector.singularize(name).to_sym
-      end
+    # @api private
+    def infer_relation(name)
+      ::Dry::Core::Inflector.pluralize(name).to_sym
+    end
 
-      # @api private
-      def infer_relation(name)
-        ::Dry::Core::Inflector.pluralize(name).to_sym
-      end
-
-      # @api private
-      def extend_builder(name, parent, &block)
-        DSL.new(name, attributes: parent.attributes, relation: parent.relation, factories: self, &block).call
-      end
+    # @api private
+    def extend_builder(name, parent, &block)
+      DSL.new(name, attributes: parent.attributes, relation: parent.relation, factories: self, &block).call
     end
   end
 end

--- a/lib/rom/factory/sequences.rb
+++ b/lib/rom/factory/sequences.rb
@@ -1,0 +1,35 @@
+require 'singleton'
+
+module ROM
+  module Factory
+    # @api private
+    class Sequences
+      include Singleton
+
+      # @api private
+      attr_reader :registry
+
+      # @api private
+      def self.[](relation)
+        key = :"#{relation.gateway}-#{relation.name.dataset}"
+        -> { instance.next(key) }
+      end
+
+      # @api private
+      def initialize
+        reset
+      end
+
+      # @api private
+      def next(key)
+        registry[key] += 1
+      end
+
+      # @api private
+      def reset
+        @registry = Concurrent::Map.new { |h, k| h[k] = 0 }
+        self
+      end
+    end
+  end
+end

--- a/lib/rom/factory/tuple_evaluator.rb
+++ b/lib/rom/factory/tuple_evaluator.rb
@@ -1,3 +1,5 @@
+require 'rom/factory/sequences'
+
 module ROM
   module Factory
     # @api private
@@ -19,7 +21,7 @@ module ROM
         @attributes = attributes
         @relation = relation.with(auto_struct: true)
         @model = @relation.combine(*assoc_names).mapper.model
-        @sequence = 0
+        @sequence = Sequences[relation]
       end
 
       # @api private
@@ -97,7 +99,7 @@ module ROM
 
       # @api private
       def next_id
-        @sequence += 1
+        sequence.()
       end
     end
   end

--- a/spec/integration/rom/factory_spec.rb
+++ b/spec/integration/rom/factory_spec.rb
@@ -416,7 +416,9 @@ RSpec.describe ROM::Factory do
   end
 
   context 'with custom struct namespace' do
-    it 'returns an instance of a custom struct' do
+    let(:entities) { factories.struct_namespace(Test::Entities) }
+
+    before do
       module Test
         module Entities
           class User < ROM::Struct
@@ -430,19 +432,36 @@ RSpec.describe ROM::Factory do
         f.email 'jane@doe.org'
         f.timestamps
       end
+    end
 
-      entities = factories.struct_namespace(Test::Entities)
+    context 'using in-memory structs' do
+      it 'returns an instance of a custom struct' do
+        result = entities.structs[:user]
 
-      result = entities[:user]
+        expect(result).to be_kind_of(Test::Entities::User)
 
-      expect(result).to be_kind_of(Test::Entities::User)
+        expect(result.id).to be(1)
+        expect(result.first_name).to eql('Jane')
+        expect(result.last_name).to eql('Doe')
+        expect(result.email).to eql('jane@doe.org')
+        expect(result.created_at).to_not be(nil)
+        expect(result.updated_at).to_not be(nil)
+      end
+    end
 
-      expect(result.id).to be(1)
-      expect(result.first_name).to eql('Jane')
-      expect(result.last_name).to eql('Doe')
-      expect(result.email).to eql('jane@doe.org')
-      expect(result.created_at).to_not be(nil)
-      expect(result.updated_at).to_not be(nil)
+    context 'using persistable structs' do
+      it 'returns an instance of a custom struct' do
+        result = entities[:user]
+
+        expect(result).to be_kind_of(Test::Entities::User)
+
+        expect(result.id).to be(1)
+        expect(result.first_name).to eql('Jane')
+        expect(result.last_name).to eql('Doe')
+        expect(result.email).to eql('jane@doe.org')
+        expect(result.created_at).to_not be(nil)
+        expect(result.updated_at).to_not be(nil)
+      end
     end
   end
 end

--- a/spec/integration/rom/factory_spec.rb
+++ b/spec/integration/rom/factory_spec.rb
@@ -414,4 +414,35 @@ RSpec.describe ROM::Factory do
       expect(result.name).to eql('Jane')
     end
   end
+
+  context 'with custom struct namespace' do
+    it 'returns an instance of a custom struct' do
+      module Test
+        module Entities
+          class User < ROM::Struct
+          end
+        end
+      end
+
+      factories.define(:user) do |f|
+        f.first_name 'Jane'
+        f.last_name 'Doe'
+        f.email 'jane@doe.org'
+        f.timestamps
+      end
+
+      entities = factories.struct_namespace(Test::Entities)
+
+      result = entities[:user]
+
+      expect(result).to be_kind_of(Test::Entities::User)
+
+      expect(result.id).to be(1)
+      expect(result.first_name).to eql('Jane')
+      expect(result.last_name).to eql('Doe')
+      expect(result.email).to eql('jane@doe.org')
+      expect(result.created_at).to_not be(nil)
+      expect(result.updated_at).to_not be(nil)
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -60,4 +60,5 @@ RSpec.configure do |config|
   config.disable_monkey_patching!
   config.warnings = warning_api_available
   config.include(Helpers)
+  config.before { ROM::Factory::Sequences.instance.reset }
 end

--- a/spec/unit/rom/factory/builder_spec.rb
+++ b/spec/unit/rom/factory/builder_spec.rb
@@ -2,7 +2,7 @@ require 'rom/factory/builder'
 
 RSpec.describe ROM::Factory::Builder do
   subject(:builder) do
-    ROM::Factory::Builder.new(ROM::Factory::AttributeRegistry.new(attributes), relation).persistable
+    ROM::Factory::Builder.new(ROM::Factory::AttributeRegistry.new(attributes), relation: relation).persistable
   end
 
   include_context 'database'


### PR DESCRIPTION
This adds support for setting custom struct namespace

``` ruby
my_factory = ROM::Factory.configure do { |c| c.rom = my_rom_container }

# for persistable structs
my_factory.struct_namespace(MyApp::Entities)[:user]

# for in-memory structs
my_factory.structs.struct_namespace(MyApp::Entities)[:user]

# this works too
my_factory.struct_namespace(MyApp::Entities).structs[:user]
```