### PR TITLE
raise error when using struct for associations

### DIFF
--- a/lib/rom/factory/constants.rb
+++ b/lib/rom/factory/constants.rb
@@ -5,5 +5,11 @@ module ROM
         super("Factory +#{name}+ not defined")
       end
     end
+
+    class UnSupportedAssociationsError < StandardError
+      def initialize
+        super('In-memory structs do not support associations')
+      end
+    end
   end
 end

--- a/lib/rom/factory/tuple_evaluator.rb
+++ b/lib/rom/factory/tuple_evaluator.rb
@@ -1,4 +1,5 @@
 require 'rom/factory/sequences'
+require 'rom/factory/constants'
 
 module ROM
   module Factory
@@ -35,7 +36,11 @@ module ROM
 
       # @api private
       def struct(*traits, attrs)
-        model.new(struct_attrs.merge(defaults(*traits, attrs)))
+        if struct_has_associations?(attributes.associations)
+          raise UnSupportedAssociationsError
+        else
+          model.new(struct_attrs.merge(defaults(*traits, attrs)))
+        end
       end
 
       # @api private
@@ -121,6 +126,10 @@ module ROM
       # @api private
       def next_id
         sequence.()
+      end
+
+      def struct_has_associations?(associations)
+        associations.any? { |assoc| assoc.dependency?(relation) }
       end
     end
   end

--- a/spec/integration/rom/factory_spec.rb
+++ b/spec/integration/rom/factory_spec.rb
@@ -472,6 +472,12 @@ RSpec.describe ROM::Factory do
         expect(t2.user_id).to be(user.id)
         expect(t2.title).to eql('Task 2')
       end
+
+      it 'raises UnSupportedAssociationError when trying to use in memory struct' do
+        expect {
+          factories.structs[:user]
+        }.to raise_error(ROM::Factory::UnSupportedAssociationsError)
+      end
     end
 
     context 'belongs_to' do


### PR DESCRIPTION
#20 

Looks like there are people are using structs with relation making it blow up. This makes using structs with associations raises an error `UnSupportedAssociationsError ` that way people know what is happening.

WDYT? @solnic 