### PR TITLE
allow accessing dependant attributes which have a reserve keyword as name

### DIFF
--- a/lib/rom/factory/tuple_evaluator.rb
+++ b/lib/rom/factory/tuple_evaluator.rb
@@ -80,7 +80,10 @@ module ROM
       # @api private
       def evaluate_values(attrs)
         attributes.values.tsort.each_with_object({}) do |attr, h|
-          deps = attr.dependency_names.map { |k| h[k] }.compact
+          deps = attr.dependency_names.map do |key|
+            h[dependecy_name(key)]
+          end.compact
+
           result = attr.(attrs, *deps)
 
           if result
@@ -89,6 +92,15 @@ module ROM
         end
       end
 
+      # @param key [Symbol]
+      # @return [Symbol]
+      #
+      # @api private
+      def dependecy_name(key)
+        key.to_s.chomp('_').to_sym
+      end
+
+      # @api private
       def evaluate_traits(*traits, **attrs)
         return {} if traits.empty?
 

--- a/spec/integration/rom/factory_spec.rb
+++ b/spec/integration/rom/factory_spec.rb
@@ -150,6 +150,19 @@ RSpec.describe ROM::Factory do
 
       expect(user.email).to eql("#{user.first_name}.#{user.last_name}@test-1.org")
     end
+
+    it 'allows to access reserve keywords by apending an underscore at the end' do
+      factories.define(:announcement) do |f|
+        f.when { ROM::SQL::Postgres::Values::Range.new(3, 9, :'[]') }
+        f.begin { |when_| when_.lower }
+        f.end { |when_| when_.upper }
+      end
+
+      announcement = factories[:announcement]
+
+      expect(announcement.begin).to eq 3
+      expect(announcement.end).to eq 9
+    end
   end
 
   context 'incomplete schema' do

--- a/spec/shared/relations.rb
+++ b/spec/shared/relations.rb
@@ -2,6 +2,7 @@ RSpec.shared_context 'relations' do
   include_context 'database'
 
   before do
+    conn.extension(:pg_range)
     conn.create_table(:users) do
       primary_key :id
       column :last_name, String, null: false
@@ -16,6 +17,17 @@ RSpec.shared_context 'relations' do
       primary_key :id
       foreign_key :user_id, :users
       column :title, String, null: false
+    end
+
+    conn.create_table(:announcements) do
+      primary_key :id
+      numrange :when, null: false
+      column :begin, Integer, null: false
+      column :end, Integer, null: false
+    end
+
+    conf.relation(:announcements) do
+      schema(infer: true)
     end
 
     conf.relation(:tasks) do
@@ -38,5 +50,6 @@ RSpec.shared_context 'relations' do
   after do
     conn.drop_table(:tasks)
     conn.drop_table(:users)
+    conn.drop_table(:announcements)
   end
 end


### PR DESCRIPTION
Fixes #16 

@solnic I was talking with @flash-gordon and we agree that this could be a good solution for this issue.

if you have a reserved keyword as one of your attributes `end`, `do`, `when` etc... you can append an underscore to the block argument and access inside the block.

#### Example

```ruby
factories.define(:announcement) do |f|
  f.when { ROM::SQL::Postgres::Values::Range.new(3, 9, :'[]') }
  f.begin { |when_| when_.lower }
  f.end { |when_| when_.upper }
end
```

