### PR TITLE
Fix overwriting values of attrs with dependant attrs

### DIFF
--- a/lib/rom/factory/attributes/callable.rb
+++ b/lib/rom/factory/attributes/callable.rb
@@ -13,8 +13,7 @@ module ROM::Factory
 
       # @api private
       def call(attrs, *args)
-        return if attrs.key?(name)
-        result = dsl.instance_exec(*args, &block)
+        result = attrs[name] || dsl.instance_exec(*args, &block)
         { name => result }
       end
 

--- a/spec/integration/rom/factory_spec.rb
+++ b/spec/integration/rom/factory_spec.rb
@@ -152,6 +152,23 @@ RSpec.describe ROM::Factory do
     end
   end
 
+  context 'changing values of dependant attributes' do
+    it 'sets correct values to attributes with overwritten dependant attributes' do
+      factories.define(:user) do |f|
+        f.first_name { fake(:name) }
+        f.last_name { fake(:name) }
+        f.email { |last_name| "#{last_name}@gmail.com" }
+        f.timestamps
+      end
+
+      overwritten_last_name = 'ivanov'
+      user = factories[:user, last_name: overwritten_last_name ]
+
+      expect(user.last_name).to eql(overwritten_last_name)
+      expect(user.email).to eq("#{overwritten_last_name}@gmail.com")
+    end
+  end
+
   context 'incomplete schema' do
     it 'fills in missing attributes' do
       factories.define(:user, relation: :users) do |f|


### PR DESCRIPTION
Hello! I have some attributes in my factory that depend on other attributes:
```
Factory.define(:user) do |f|
  f.first_name { fake(:name) }
  f.last_name { fake(:name) }
  f.email { |last_name| "#{last_name}@gmail.com" }
  f.timestamps
end
```
For some reason I have to overwrite `last_name` and still get correct `email`:

```
Factory[:user, last_name: 'OtherLastName']
```
But I get `@gmail.com` instead of `OtherLastName@gmail.com`. Here is a fix for it.
