### PR TITLE
 Allow DATABASE_URL from env 

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 if RUBY_ENGINE == 'ruby' && ENV['COVERAGE'] == 'true'
   require 'yaml'
-  rubies = YAML.load(File.read(File.join(__dir__, '..', '.travis.yml')))['rvm']
+  rubies = YAML.safe_load(File.read(File.join(__dir__, '..', '.travis.yml')))['rvm']
   latest_mri = rubies.select { |v| v =~ /\A\d+\.\d+.\d+\z/ }.max
 
   if RUBY_VERSION == latest_mri
@@ -36,6 +36,16 @@ DB_URI = ENV.fetch('DATABASE_URL') do
   else
     'postgres://localhost/rom_factory'
   end
+end
+
+def local_database_url?
+  ['localhost', '0.0.0.0', '127.0.0.1'].include? URI.parse(DB_URI).host
+end
+
+unless local_database_url?
+  warn "DATABASE_URL (#{DB_URI}) is not a local database, aborting" \
+       "to ensure we don't destroy production data."
+  abort
 end
 
 warning_api_available = RUBY_VERSION >= '2.4.0'


### PR DESCRIPTION
This PR lowers the barrier of entry for contributing by allowing a developer to specify `DATABASE_URL` to use in specs. To be safe, we make sure this `DATABASE_URL` is a local database.