### PR TITLE
Do not persist many-to-one child records when building a struct

### DIFF
--- a/lib/rom/factory/builder.rb
+++ b/lib/rom/factory/builder.rb
@@ -26,7 +26,7 @@ module ROM::Factory
 
     # @api private
     def tuple(*traits, **attrs)
-      tuple_evaluator.defaults(*traits, attrs)
+      tuple_evaluator.defaults(traits, attrs)
     end
 
     # @api private

--- a/spec/integration/rom/factory_spec.rb
+++ b/spec/integration/rom/factory_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe ROM::Factory do
       expect(user1.class).to be(user2.class)
     end
 
-    it 'works with one to many relationships' do
+    it 'works with one to many relationships when building parent' do
       factories.define(:task) do |f|
         f.sequence(:title) { |n| "Task #{n}" }
       end
@@ -61,8 +61,25 @@ RSpec.describe ROM::Factory do
 
       expect(user_with_tasks.tasks.length).to eql(2)
       expect(relations[:tasks].count).to be_zero
+      expect(relations[:users].count).to be_zero
       expect(user_with_tasks.tasks).to all(respond_to(:title, :user_id))
       expect(user_with_tasks.tasks).to all(have_attributes(user_id: user_with_tasks.id))
+    end
+
+    it 'does not create records when building child' do
+      factories.define(:task) do |f|
+        f.sequence(:title) { |n| "Task #{n}" }
+      end
+
+      factories.define(:user) do |f|
+        f.timestamps
+        f.association(:tasks, count: 2)
+      end
+
+      factories.structs[:task]
+
+      expect(relations[:tasks].count).to be_zero
+      expect(relations[:users].count).to be_zero
     end
 
     context 'one-to-one' do
@@ -98,9 +115,7 @@ RSpec.describe ROM::Factory do
       before do
         conn.drop_table?(:basic_accounts)
         conn.drop_table?(:basic_users)
-      end
 
-      it 'works with one to one relationships' do
         factories.define(:basic_user) do |f|
           f.association(:basic_account)
         end
@@ -108,12 +123,21 @@ RSpec.describe ROM::Factory do
         factories.define(:basic_account) do |f|
           f.association(:basic_user)
         end
+      end
 
+      it 'works with one to one relationships with parent' do
         user = factories.structs[:basic_user]
 
         expect(relations[:basic_accounts].count).to be_zero
         expect(relations[:basic_users].count).to be_zero
         expect(user.basic_account).to have_attributes(basic_user_id: user.id)
+      end
+
+      it 'does not persist when building a child struct' do
+        factories.structs[:basic_account]
+
+        expect(relations[:basic_accounts].count).to be_zero
+        expect(relations[:basic_users].count).to be_zero
       end
     end
   end


### PR DESCRIPTION
This is a follow up to https://github.com/rom-rb/rom-factory/pull/30

Previously, building a many-to-one (`belongs_to`) record would persist the record to the DB. This patch addresses that issue by ensuring the `persist: false` option is honored in `ManyToOne` relationships.