### PR TITLE
Raise error when trying to set missing attribute

### DIFF
--- a/lib/rom/factory/builder/persistable.rb
+++ b/lib/rom/factory/builder/persistable.rb
@@ -23,6 +23,7 @@ module ROM
         # @api private
         def create(*traits, **attrs)
           tuple = tuple(*traits, attrs)
+          validate_keys(traits, tuple)
           persisted = persist(tuple)
 
           if tuple_evaluator.has_associations?(traits)
@@ -46,6 +47,15 @@ module ROM
         # @api private
         def primary_key_names
           relation.schema.primary_key.map(&:name)
+        end
+
+        # @api private
+        def validate_keys(traits, tuple)
+          schema_keys = relation.schema.attributes.map(&:name)
+          assoc_keys = tuple_evaluator.assoc_names(traits)
+          unknown_keys = tuple.keys - schema_keys - assoc_keys
+
+          raise UnknownFactoryAttributes, unknown_keys unless unknown_keys.empty?
         end
       end
     end

--- a/lib/rom/factory/constants.rb
+++ b/lib/rom/factory/constants.rb
@@ -7,5 +7,11 @@ module ROM
         super("Factory +#{name}+ not defined")
       end
     end
+
+    class UnknownFactoryAttributes < StandardError
+      def initialize(attrs)
+        super("Unknown attributes: #{attrs.join(', ')}")
+      end
+    end
   end
 end

--- a/spec/integration/rom/factory_spec.rb
+++ b/spec/integration/rom/factory_spec.rb
@@ -289,6 +289,19 @@ RSpec.describe ROM::Factory do
 
       expect { define.() }.to raise_error(ArgumentError)
     end
+
+    it 'raises error when trying to set missing attribute' do
+      factories.define(:user, relation: :users) do |f|
+        f.first_name 'Janis'
+        f.last_name 'Miezitis'
+        f.email 'janjiss@gmail.com'
+        f.timestamps
+      end
+
+      expect {
+        factories[:user, not_real_attribute: "invalid attribute value"]
+      }.to raise_error(ROM::Factory::UnknownFactoryAttributes)
+    end
   end
 
   context 'sequence' do
@@ -647,7 +660,7 @@ RSpec.describe ROM::Factory do
       end
 
       it 'allows overrides' do
-        user = factories[:user, name: "Joe"]
+        user = factories[:user, first_name: "Joe"]
         task = factories[:task, user: user]
 
         expect(task.title).to eql('A task')


### PR DESCRIPTION
I always typo some attribute name when using a factory. `rom-factory` ignores these typos. This PR makes `rom-factory` raise an error instead of the currently "ignore all the things" functionality. 

I am not sure if this is the best way to solve this problem but "it works" 🤷‍♂ 