### PR TITLE
Honor zero count on one-to-one associations

### DIFF
--- a/lib/rom/factory/attributes/association.rb
+++ b/lib/rom/factory/attributes/association.rb
@@ -99,6 +99,9 @@ module ROM::Factory
       class OneToOne < OneToMany
         # @api private
         def call(attrs = EMPTY_HASH, parent, opts)
+          # do not associate if count is 0
+          return { name => nil } if count.zero?
+
           return if attrs.key?(name)
 
           association_hash = assoc.associate(attrs, parent)
@@ -113,6 +116,11 @@ module ROM::Factory
                    end
 
           { name => struct }
+        end
+
+        # @api private
+        def count
+          options.fetch(:count, 1)
         end
       end
     end

--- a/lib/rom/factory/dsl.rb
+++ b/lib/rom/factory/dsl.rb
@@ -124,11 +124,16 @@ module ROM
       #
       # @param [Symbol] name The name of the configured association
       # @param [Hash] options Additional options
-      # @option options [Integer] count Number of objects to generate (has-many only)
+      # @option options [Integer] count Number of objects to generate
       #
       # @api public
       def association(name, *traits, **options)
         assoc = _relation.associations[name]
+
+        if assoc.is_a?(::ROM::SQL::Associations::OneToOne) && options.fetch(:count, 1) > 1
+          ::Kernel.raise ::ArgumentError, 'count cannot be greater than 1 on a OneToOne'
+        end
+
         builder = -> { _factories.for_relation(assoc.target) }
 
         _attributes << attributes::Association.new(assoc, builder, *traits, **options)

--- a/spec/integration/rom/factory_spec.rb
+++ b/spec/integration/rom/factory_spec.rb
@@ -213,6 +213,23 @@ RSpec.describe ROM::Factory do
           expect(user.basic_account).to be_nil
         end
       end
+
+      context 'when the count is greater than 0' do
+        before do
+          conn.drop_table?(:basic_accounts)
+          conn.drop_table?(:basic_users)
+        end
+
+        it 'raises an ArgumentError' do
+          defining_with_count_greater_than_zero = proc do
+            factories.define(:basic_user) do |f|
+              f.association(:basic_account, count: 2)
+            end
+          end
+
+          expect(&defining_with_count_greater_than_zero).to raise_error(ArgumentError)
+        end
+      end
     end
   end
 

--- a/spec/integration/rom/factory_spec.rb
+++ b/spec/integration/rom/factory_spec.rb
@@ -186,6 +186,33 @@ RSpec.describe ROM::Factory do
           expect(basic_user.basic_account).to respond_to(:id)
         end
       end
+
+      context 'when the count is specified as 0' do
+        before do
+          conn.drop_table?(:basic_accounts)
+          conn.drop_table?(:basic_users)
+
+          factories.define(:basic_user) do |f|
+            f.association(:basic_account, count: 0)
+          end
+
+          factories.define(:basic_account) do |f|
+            f.association(:basic_user)
+          end
+        end
+
+        it 'does not create the related record' do
+          user = factories[:basic_user]
+
+          expect(user.basic_account).to be_nil
+        end
+
+        it 'does not build the related record' do
+          user = factories.structs[:basic_user]
+
+          expect(user.basic_account).to be_nil
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Previously, `rom-factory` ignored the `count` param of an association. This can lead to unexpected behavior, and potentially create records which a user would not expect to exist.

This PR makes it so if `count: 0` is specified on a `OneToOne` relationship, `rom-factory` will not create or build an associated record.