### PR TITLE
Fix TupleEvaluator#struct_attrs for non-standard output schema

### DIFF
--- a/lib/rom/factory/tuple_evaluator.rb
+++ b/lib/rom/factory/tuple_evaluator.rb
@@ -136,11 +136,15 @@ module ROM
 
       # @api private
       def struct_attrs
-        relation.schema.
+        struct_attrs = relation.schema.
           reject(&:primary_key?).
-          map { |attr| [attr.name, nil] }.
-          to_h.
-          merge(primary_key => next_id)
+          map { |attr| [attr.name, nil] }.to_h
+
+        if primary_key
+          struct_attrs.merge(primary_key => next_id)
+        else
+          struct_attrs
+        end
       end
 
       # @api private

--- a/spec/integration/rom/factory_spec.rb
+++ b/spec/integration/rom/factory_spec.rb
@@ -599,6 +599,32 @@ RSpec.describe ROM::Factory do
     end
   end
 
+  context 'with a custom output schema' do
+    it "doesn't assume primary_key exists" do
+      factories.define(:key_values) do |f|
+        f.key 'a_key'
+        f.value 'a_value'
+      end
+
+      result = factories[:key_values]
+
+      expect(result.key).to eql('a_key')
+      expect(result.value).to eql('a_value')
+    end
+
+    it "doesn't assume primary_key exists for a struct" do
+      factories.define(:key_values) do |f|
+        f.key 'a_key'
+        f.value 'a_value'
+      end
+
+      result = factories.structs[:key_values]
+
+      expect(result.key).to eql('a_key')
+      expect(result.value).to eql('a_value')
+    end
+  end
+
   context 'using builders within callable blocks' do
     it 'exposes create method in callable attribute blocks' do
       factories.define(:user) do |f|

--- a/spec/shared/relations.rb
+++ b/spec/shared/relations.rb
@@ -20,6 +20,11 @@ RSpec.shared_context 'relations' do
       column :title, String, null: false
     end
 
+    conn.create_table(:key_values) do
+      column :key, String
+      column :value, String
+    end
+
     conf.relation(:tasks) do
       schema(infer: true) do
         associations do
@@ -35,10 +40,21 @@ RSpec.shared_context 'relations' do
         end
       end
     end
+
+    conf.relation(:key_values) do
+      option :output_schema, default: -> do
+        ROM::Types::Hash.schema(
+          schema.map { |attr| [attr.key, attr.to_read_type] }.to_h
+        ).with_key_transform(&:to_sym)
+      end
+
+      schema(infer: true) {}
+    end
   end
 
   after do
     conn.drop_table(:tasks)
     conn.drop_table(:users)
+    conn.drop_table(:key_values)
   end
 end


### PR DESCRIPTION
Prior to this, using a non-standard output schema that doesn't reject keys that are not present in the schema (as in `rom-http`), and with no PK defined on the schema, the `TupleEvaluator#struct_attrs` method would try to add a sequence value under the PK name, as `#primary_key` evaluated to `nil`, the attribute added looked like `"nil=>{n}"`, and the following error would occur (with rom-http output schema):

```
NoMethodError:
 undefined method `to_sym' for nil:NilClass
```

The attribute was added in all cases where no PK was present, but was only noticeable when the output schema didn't reject keys that weren't defined in the schema.