### PR TITLE
add struct_namespace option to builders

### DIFF
--- a/lib/rom/factory/builder.rb
+++ b/lib/rom/factory/builder.rb
@@ -46,8 +46,7 @@ module ROM::Factory
     # @api private
     def struct_namespace(namespace)
       if options[:struct_namespace][:overridable]
-        with(struct_namespace: options[:struct_namespace].merge(namespace: namespace),
-             relation: relation.struct_namespace(namespace))
+        with(struct_namespace: options[:struct_namespace].merge(namespace: namespace))
       else
         self
       end

--- a/lib/rom/factory/dsl.rb
+++ b/lib/rom/factory/dsl.rb
@@ -27,14 +27,15 @@ module ROM
     class DSL < BasicObject
       define_method(:rand, ::Kernel.instance_method(:rand))
 
-      attr_reader :_name, :_relation, :_attributes, :_factories, :_valid_names
+      attr_reader :_name, :_relation, :_attributes, :_factories, :_struct_namespace, :_valid_names
       attr_reader :_traits
 
       # @api private
-      def initialize(name, attributes: AttributeRegistry.new, relation:, factories:)
+      def initialize(name, attributes: AttributeRegistry.new, relation:, factories:, struct_namespace:)
         @_name = name
         @_relation = relation
         @_factories = factories
+        @_struct_namespace = struct_namespace
         @_attributes = attributes.dup
         @_traits = {}
         @_valid_names = _relation.schema.attributes.map(&:name)
@@ -43,7 +44,7 @@ module ROM
 
       # @api private
       def call
-        ::ROM::Factory::Builder.new(_attributes, _traits, relation: _relation)
+        ::ROM::Factory::Builder.new(_attributes, _traits, relation: _relation, struct_namespace: _struct_namespace)
       end
 
       # Delegate to a builder and persist a struct
@@ -110,6 +111,7 @@ module ROM
           ),
           relation: _relation,
           factories: _factories,
+          struct_namespace: _struct_namespace,
           &block
         )._attributes
       end

--- a/spec/integration/rom/factory_spec.rb
+++ b/spec/integration/rom/factory_spec.rb
@@ -437,7 +437,7 @@ RSpec.describe ROM::Factory do
       end
     end
 
-    context 'without struct_namespace option' do
+    context 'with struct_namespace option' do
       before do
         module Test
           module Entities
@@ -446,7 +446,7 @@ RSpec.describe ROM::Factory do
           end
 
           module AnotherEntities
-            class John < ROM::Struct
+            class Admin < ROM::Struct
             end
           end
         end
@@ -461,6 +461,10 @@ RSpec.describe ROM::Factory do
           f.email 'jane@doe.org'
         end
 
+        factories.define({admin: :jane}, struct_namespace: Test::AnotherEntities) do |f|
+          f.type 'Admin'
+        end
+
         factories.define({ john: :jane }, struct_namespace: Test::AnotherEntities) do |f|
           f.first_name 'John'
           f.email 'john@doe.org'
@@ -470,11 +474,17 @@ RSpec.describe ROM::Factory do
       context 'using in-memory structs' do
         let(:jane) { factories.structs[:jane] }
         let(:john) { factories.structs[:john] }
+        let(:admin) { factories.structs[:admin] }
 
         it 'sets up a new builder based on another with correct struct_namespace' do
           expect(jane.first_name).to eql('Jane')
           expect(jane.email).to eql('jane@doe.org')
           expect(jane).to be_kind_of(Test::Entities::User)
+
+          expect(jane.first_name).to eql('Jane')
+          expect(jane.email).to eql('jane@doe.org')
+          expect(admin.type).to eql('Admin')
+          expect(admin).to be_kind_of(Test::AnotherEntities::Admin)
 
           expect(john.first_name).to eql('John')
           expect(john.last_name).to eql('Doe')
@@ -486,11 +496,17 @@ RSpec.describe ROM::Factory do
       context 'using persistable structs' do
         let(:jane) { factories[:jane] }
         let(:john) { factories[:john] }
+        let(:admin) { factories[:admin] }
 
         it 'sets up a new builder based on another with correct struct_namespace' do
           expect(jane.first_name).to eql('Jane')
           expect(jane.email).to eql('jane@doe.org')
           expect(jane).to be_kind_of(Test::Entities::User)
+
+          expect(jane.first_name).to eql('Jane')
+          expect(jane.email).to eql('jane@doe.org')
+          expect(admin.type).to eql('Admin')
+          expect(admin).to be_kind_of(Test::AnotherEntities::Admin)
 
           expect(john.first_name).to eql('John')
           expect(john.last_name).to eql('Doe')

--- a/spec/shared/relations.rb
+++ b/spec/shared/relations.rb
@@ -12,6 +12,7 @@ RSpec.shared_context 'relations' do
       column :created_at, Time, null: false
       column :updated_at, Time, null: false
       column :age, Integer
+      column :type, String
     end
 
     conn.create_table(:tasks) do
@@ -30,6 +31,16 @@ RSpec.shared_context 'relations' do
 
     conf.relation(:users) do
       schema(infer: true) do
+        associations do
+          has_many :tasks
+        end
+      end
+    end
+
+    conf.relation(:admins) do
+      dataset { where(type: "Admin") }
+
+      schema(:users, as: :admins, infer: true) do
         associations do
           has_many :tasks
         end

--- a/spec/unit/rom/factory/builder_spec.rb
+++ b/spec/unit/rom/factory/builder_spec.rb
@@ -4,7 +4,9 @@ require 'rom/factory/builder'
 
 RSpec.describe ROM::Factory::Builder do
   subject(:builder) do
-    ROM::Factory::Builder.new(ROM::Factory::AttributeRegistry.new(attributes), relation: relation).persistable
+    ROM::Factory::Builder.new(ROM::Factory::AttributeRegistry.new(attributes),
+                              relation: relation,
+                              struct_namespace: { namespace: ROM::Struct, overridable: true }).persistable
   end
 
   include_context 'database'


### PR DESCRIPTION
added the ability to pass the struct_namespace parameter to builder so you can create different builders with different struct namespaces within one factory 