### PR TITLE
Fix wrong information about building memory object

### DIFF
--- a/docsite/source/index.html.md
+++ b/docsite/source/index.html.md
@@ -145,7 +145,10 @@ end
 
 ```ruby
 # Create in-memory object
-Factory.structs(:user)
+Factory.structs[:user]
+
+# Override attributes in the in-memory object
+Factory.structs[:user, id: 1]
 
 # Persist struct in database
 Factory[:user]


### PR DESCRIPTION
Hey, I found the issue in the documentation:

```
(rdb:1) Factory.structs[:payment, id: 3]
#<ROM::Struct::Payment id=3 ...>

(rdb:1) Factory.structs(:payment, id: 3)
/Users/anton/.rvm/rubies/ruby-2.7.0/lib/ruby/2.7.0/debug.rb:286:in `eval':wrong number of arguments (given 2, expected 0)
```