### PR TITLE
Cache faker constants

### DIFF
--- a/lib/rom/factory/dsl.rb
+++ b/lib/rom/factory/dsl.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'faker'
+require 'dry/core/cache'
 require 'dry/core/inflector'
 
 require 'rom/factory/builder'
@@ -9,10 +10,14 @@ require 'rom/factory/attributes'
 
 module ROM
   module Factory
+    extend ::Dry::Core::Cache
+
     class << self
       # @api private
       def fake(type, *args)
-        api = ::Faker.const_get(::Dry::Core::Inflector.classify(type.to_s))
+        api = fetch_or_store(:faker, type) do
+          ::Faker.const_get(::Dry::Core::Inflector.classify(type.to_s))
+        end
 
         if args[0].is_a?(Symbol)
           api.public_send(*args)


### PR DESCRIPTION
Naive benchmark

```ruby
require 'faker'
require 'dry/core/cache'
require 'dry/core/inflector'
require 'benchmark/ips'

class Context
  extend ::Dry::Core::Cache

  def get_faker_constant_cache(type)
    fetch_or_store(:faker, type) do
      ::Faker.const_get(::Dry::Core::Inflector.classify(type.to_s))
    end
  end

  def get_faker_constant(type)
    ::Faker.const_get(::Dry::Core::Inflector.classify(type.to_s))
  end
end

context = Context.new

Benchmark.ips do |x|
  x.report('cached') do
    context.get_faker_constant_cache(:lorem)
  end

  x.report('non-cached') do
    context.get_faker_constant(:lorem)
  end

  x.compare!
end
```

Results
```
Warming up --------------------------------------
              cached   189.223k i/100ms
          non-cached     4.880k i/100ms
Calculating -------------------------------------
              cached      1.885M (± 3.0%) i/s -      9.461M in   5.022745s
          non-cached     48.538k (± 3.9%) i/s -    244.000k in   5.035273s

Comparison:
              cached:  1885412.7 i/s
          non-cached:    48538.0 i/s - 38.84x  (± 0.00) slower
```