### PR TITLE
Expose plural faker generators like "Faker::GreekPhilosophers" properly

### DIFF
--- a/lib/rom/factory/dsl.rb
+++ b/lib/rom/factory/dsl.rb
@@ -16,7 +16,7 @@ module ROM
       # @api private
       def fake(type, *args)
         api = fetch_or_store(:faker, type) do
-          ::Faker.const_get(::Dry::Core::Inflector.classify(type.to_s))
+          ::Faker.const_get(::Dry::Core::Inflector.camelize(type))
         end
 
         if args[0].is_a?(Symbol)

--- a/spec/integration/rom/factory_spec.rb
+++ b/spec/integration/rom/factory_spec.rb
@@ -730,6 +730,7 @@ RSpec.describe ROM::Factory do
       factories.define(:user) do |f|
         f.first_name { fake(:name) }
         f.last_name { fake(:name, :last_name) }
+        f.alias { fake(:greek_philosophers, :name) }
         f.email { fake(:internet, :email) }
         f.timestamps
       end
@@ -739,6 +740,7 @@ RSpec.describe ROM::Factory do
       expect(user.id).to_not be(nil)
       expect(user.first_name).to_not be(nil)
       expect(user.last_name).to_not be(nil)
+      expect(user.alias).to_not be(nil)
       expect(user.email).to_not be(nil)
       expect(user.created_at).to_not be(nil)
       expect(user.created_at).to_not be(nil)

--- a/spec/shared/relations.rb
+++ b/spec/shared/relations.rb
@@ -8,6 +8,7 @@ RSpec.shared_context 'relations' do
       primary_key :id
       column :last_name, String, null: false
       column :first_name, String, null: false
+      column :alias, String, null: true
       column :email, String, null: false
       column :created_at, Time, null: false
       column :updated_at, Time, null: false


### PR DESCRIPTION
`classify` singularizes the input. `camelize` doesn't. Before that change `f.alias { fake(:greek_philosophers, :name) }` raised an exception.

Thanks and best regards