### PR TITLE
Make registry fully thread safe

### DIFF
--- a/lib/rom/factory/sequences.rb
+++ b/lib/rom/factory/sequences.rb
@@ -19,12 +19,15 @@ module ROM
 
       # @api private
       def initialize
+        @mutex = Mutex.new
         reset
       end
 
       # @api private
       def next(key)
-        registry[key] += 1
+        @mutex.synchronize do
+          registry[key] += 1
+        end
       end
 
       # @api private

--- a/lib/rom/factory/sequences.rb
+++ b/lib/rom/factory/sequences.rb
@@ -29,7 +29,7 @@ module ROM
 
       # @api private
       def reset
-        @registry = Concurrent::Map.new { |h, k| h[k] = 0 }
+        @registry = Concurrent::Map.new { |h, k| h.compute_if_absent(k) { 0 } }
         self
       end
     end


### PR DESCRIPTION
Without this change potential incrementation can "go away" and can actually mismatch by 1 if run in multiple threads the same time. This can lead to super weird errors where counter is not as expected (been there, took me ages to debug).

ref: https://github.com/ruby-concurrency/concurrent-ruby/issues/970