### PR TITLE
Remove version restriction from `pry` in `Gemfile`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ git "https://github.com/rom-rb/rom.git", branch: "release-5.3" do
 end
 
 group :test do
-  gem "pry", "~> 0.12.0", "<= 0.13"
+  gem "pry"
   gem "pry-byebug", "~> 3.8", platforms: :ruby
   gem "rom-sql", github: "rom-rb/rom-sql", branch: "release-3.6"
 


### PR DESCRIPTION
I had errors from `pry` while booting until I let it use the latest version.