### PR TITLE
Add support for named `traits` arg with `association`

### DIFF
--- a/lib/rom/factory/dsl.rb
+++ b/lib/rom/factory/dsl.rb
@@ -139,9 +139,13 @@ module ROM
       # @example has-many
       #   f.association(:posts, count: 2)
       #
+      # @example adding traits
+      #   f.association(:posts, traits: [:published])
+      #
       # @param [Symbol] name The name of the configured association
       # @param [Hash] options Additional options
       # @option options [Integer] count Number of objects to generate
+      # @option options [Array<Symbol>] traits Traits to apply to the association
       #
       # @api public
       def association(name, *traits, **options)
@@ -150,6 +154,8 @@ module ROM
         if assoc.is_a?(::ROM::SQL::Associations::OneToOne) && options.fetch(:count, 1) > 1
           ::Kernel.raise ::ArgumentError, "count cannot be greater than 1 on a OneToOne"
         end
+
+        traits ||= options.fetch(:traits, EMPTY_ARRAY)
 
         builder = -> { _factories.for_relation(assoc.target) }
 

--- a/lib/rom/factory/dsl.rb
+++ b/lib/rom/factory/dsl.rb
@@ -155,7 +155,7 @@ module ROM
           ::Kernel.raise ::ArgumentError, "count cannot be greater than 1 on a OneToOne"
         end
 
-        traits ||= options.fetch(:traits, EMPTY_ARRAY)
+        traits = options.fetch(:traits, EMPTY_ARRAY) if traits.empty?
 
         builder = -> { _factories.for_relation(assoc.target) }
 


### PR DESCRIPTION
Traits can currently be specified as the second argument when calling
`association`:

```ruby
Factory.define :category do |category|
  category.association :image, :fancy 
end
```

This change will add support for specifying `traits:` as an option:

```ruby
Factory.define :category do |category|
  category.association :image, traits: [:fancy]
end
```