### PR TITLE
Introduce ManyToMany and OneToOneThrough builder

### DIFF
--- a/lib/rom/factory/attribute_registry.rb
+++ b/lib/rom/factory/attribute_registry.rb
@@ -50,6 +50,10 @@ module ROM
         self.class.new(elements.select { |e| e.is_a?(Attributes::Association::Core) })
       end
 
+      def reject(&block)
+        self.class.new(elements.reject(&block))
+      end
+
       private
 
       # @api private

--- a/lib/rom/factory/attributes/association.rb
+++ b/lib/rom/factory/attributes/association.rb
@@ -75,14 +75,27 @@ module ROM::Factory
           elsif assoc_data.is_a?(ROM::Struct)
             assoc.associate(attrs, assoc_data)
           elsif !(attrs.key?(name) && attrs[name].nil?) && !attrs[foreign_key]
-            struct = if persist
-                       builder.persistable.create(*traits, **assoc_data)
+            parent = if persist
+                       builder.persistable.create(*parent_traits, **assoc_data)
                      else
-                       builder.struct(*traits, **assoc_data)
+                       builder.struct(*parent_traits, **assoc_data)
                      end
-            tuple = {name => struct}
-            assoc.associate(tuple, struct)
+
+            tuple = {name => parent}
+
+            assoc.associate(tuple, parent)
           end
+        end
+
+        private
+
+        def parent_traits
+          @parent_traits ||=
+            if assoc.target.associations.key?(assoc.source.name)
+              traits + [assoc.target.associations[assoc.source.name].name => false]
+            else
+              traits
+            end
         end
       end
 

--- a/lib/rom/factory/attributes/association.rb
+++ b/lib/rom/factory/attributes/association.rb
@@ -69,13 +69,15 @@ module ROM::Factory
         # @api private
         # rubocop:disable Metrics/AbcSize
         def call(attrs, persist: true)
+          return if attrs.key?(name) && attrs[name].nil?
+
           assoc_data = attrs.fetch(name, EMPTY_HASH)
 
-          if assoc_data && assoc_data[assoc.source.primary_key] && !attrs[foreign_key]
+          if assoc_data.is_a?(Hash) && assoc_data[assoc.target.primary_key] && !attrs[foreign_key]
             assoc.associate(attrs, attrs[name])
           elsif assoc_data.is_a?(ROM::Struct)
             assoc.associate(attrs, assoc_data)
-          elsif !(attrs.key?(name) && attrs[name].nil?) && !attrs[foreign_key]
+          elsif !attrs[foreign_key]
             parent = if persist
                        builder.persistable.create(*parent_traits, **assoc_data)
                      else

--- a/lib/rom/factory/attributes/association.rb
+++ b/lib/rom/factory/attributes/association.rb
@@ -77,11 +77,14 @@ module ROM::Factory
             assoc.associate(attrs, attrs[name])
           elsif assoc_data.is_a?(ROM::Struct)
             assoc.associate(attrs, assoc_data)
-          elsif !attrs[foreign_key]
-            parent = if persist
+          else
+            parent = if persist && !attrs[foreign_key]
                        builder.persistable.create(*parent_traits, **assoc_data)
                      else
-                       builder.struct(*parent_traits, **assoc_data)
+                       builder.struct(
+                         *parent_traits,
+                         **assoc_data.merge(assoc.target.primary_key => attrs[foreign_key])
+                       )
                      end
 
             tuple = {name => parent}

--- a/lib/rom/factory/attributes/association.rb
+++ b/lib/rom/factory/attributes/association.rb
@@ -68,9 +68,11 @@ module ROM::Factory
       class ManyToOne < Core
         # @api private
         def call(attrs, persist: true)
-          if attrs.key?(name) && !attrs[foreign_key]
+          assoc_data = attrs[name]
+
+          if assoc_data && !attrs[foreign_key]
             assoc.associate(attrs, attrs[name])
-          elsif !attrs[foreign_key]
+          elsif !(attrs.key?(name) && attrs[name].nil?) && !attrs[foreign_key]
             struct = if persist
                        builder.persistable.create(*traits)
                      else

--- a/lib/rom/factory/attributes/association.rb
+++ b/lib/rom/factory/attributes/association.rb
@@ -67,6 +67,7 @@ module ROM::Factory
       # @api private
       class ManyToOne < Core
         # @api private
+        # rubocop:disable Metrics/AbcSize
         def call(attrs, persist: true)
           assoc_data = attrs.fetch(name, EMPTY_HASH)
 
@@ -86,6 +87,7 @@ module ROM::Factory
             assoc.associate(tuple, parent)
           end
         end
+        # rubocop:enable Metrics/AbcSize
 
         private
 

--- a/lib/rom/factory/attributes/association.rb
+++ b/lib/rom/factory/attributes/association.rb
@@ -96,7 +96,7 @@ module ROM::Factory
         def parent_traits
           @parent_traits ||=
             if assoc.target.associations.key?(assoc.source.name)
-              traits + [assoc.target.associations[assoc.source.name].name => false]
+              traits + [assoc.target.associations[assoc.source.name].key => false]
             else
               traits
             end

--- a/lib/rom/factory/builder.rb
+++ b/lib/rom/factory/builder.rb
@@ -28,6 +28,10 @@ module ROM::Factory
     #   @return [Module] Custom struct namespace
     option :struct_namespace, reader: false
 
+    # @!attribute [r] factories
+    #   @return [Module] Factories with other builders
+    option :factories, reader: true, optional: true
+
     # @api private
     def tuple(*traits, **attrs)
       tuple_evaluator.defaults(traits, attrs)

--- a/lib/rom/factory/builder.rb
+++ b/lib/rom/factory/builder.rb
@@ -61,7 +61,11 @@ module ROM::Factory
 
     # @api private
     def tuple_evaluator
-      @__tuple_evaluator__ ||= TupleEvaluator.new(attributes, tuple_evaluator_relation, traits)
+      @__tuple_evaluator__ ||= TupleEvaluator.new(
+        attributes,
+        tuple_evaluator_relation,
+        traits
+      )
     end
 
     # @api private

--- a/lib/rom/factory/builder/persistable.rb
+++ b/lib/rom/factory/builder/persistable.rb
@@ -22,8 +22,9 @@ module ROM
 
         # @api private
         def create(*traits, **attrs)
-          tuple = tuple(*traits, **attrs)
           validate_keys(traits, attrs)
+
+          tuple = tuple(*traits, **attrs)
           persisted = persist(tuple)
 
           if tuple_evaluator.has_associations?(traits)

--- a/lib/rom/factory/dsl.rb
+++ b/lib/rom/factory/dsl.rb
@@ -50,7 +50,13 @@ module ROM
 
       # @api private
       def call
-        ::ROM::Factory::Builder.new(_attributes, _traits, relation: _relation, struct_namespace: _struct_namespace)
+        ::ROM::Factory::Builder.new(
+          _attributes,
+          _traits,
+          relation: _relation,
+          struct_namespace: _struct_namespace,
+          factories: _factories
+        )
       end
 
       # Delegate to a builder and persist a struct

--- a/lib/rom/factory/tuple_evaluator.rb
+++ b/lib/rom/factory/tuple_evaluator.rb
@@ -60,7 +60,7 @@ module ROM
       end
 
       # @api private
-      def struct(*traits, **attrs) # rubocop:disable Metrics/AbcSize
+      def struct(*traits, **attrs)
         merged_attrs = struct_attrs.merge(defaults(traits, attrs, persist: false))
         is_callable = proc { |_name, value| value.respond_to?(:call) }
 
@@ -74,7 +74,7 @@ module ROM
 
         attributes.merge!(materialized_callables)
 
-        associations = attrs.slice(*assoc_names(traits)).merge(assoc_names(traits)
+        assoc_attrs = attributes.slice(*assoc_names(traits)).merge(assoc_names(traits)
           .select { |key|
             build_assoc?(key, attributes)
           }
@@ -83,10 +83,10 @@ module ROM
           }
           .to_h)
 
-        attributes = relation.output_schema[attributes]
-        attributes.update(associations)
+        model_attrs = relation.output_schema[attributes]
+        model_attrs.update(assoc_attrs)
 
-        model(traits).new(attributes)
+        model(traits).new(**model_attrs)
       rescue StandardError => e
         raise TupleEvaluatorError.new(relation, e, attrs, traits, assoc_attrs)
       end

--- a/lib/rom/factory/tuple_evaluator.rb
+++ b/lib/rom/factory/tuple_evaluator.rb
@@ -135,7 +135,7 @@ module ROM
 
         traits = trait_list.map { |v| v.is_a?(Hash) ? v : {v => true} }.reduce(:merge)
 
-        traits_attrs = self.traits.select { |key, value| traits[key] }.values.flat_map(&:elements)
+        traits_attrs = self.traits.select { |key, _value| traits[key] }.values.flat_map(&:elements)
         registry = AttributeRegistry.new(traits_attrs)
         self.class.new(registry, relation).defaults([], attrs, **opts)
       end

--- a/lib/rom/factory/tuple_evaluator.rb
+++ b/lib/rom/factory/tuple_evaluator.rb
@@ -68,20 +68,22 @@ module ROM
         attributes = merged_attrs.reject(&is_callable)
 
         materialized_callables = {}
-        callables.each do |_name, callable|
+        callables.each_value do |callable|
           materialized_callables.merge!(callable.call(attributes, persist: false))
         end
 
         attributes.merge!(materialized_callables)
 
-        assoc_attrs = attributes.slice(*assoc_names(traits)).merge(assoc_names(traits)
-          .select { |key|
-            build_assoc?(key, attributes)
-          }
-          .map { |key|
-            [key, build_assoc_attrs(key, attributes[relation.primary_key], attributes[key])]
-          }
-          .to_h)
+        assoc_attrs = attributes.slice(*assoc_names(traits)).merge(
+          assoc_names(traits)
+            .select { |key|
+              build_assoc?(key, attributes)
+            }
+            .map { |key|
+              [key, build_assoc_attrs(key, attributes[relation.primary_key], attributes[key])]
+            }
+          .to_h
+        )
 
         model_attrs = relation.output_schema[attributes]
         model_attrs.update(assoc_attrs)
@@ -91,8 +93,8 @@ module ROM
         raise TupleEvaluatorError.new(relation, e, attrs, traits, assoc_attrs)
       end
 
-      def build_assoc?(key, attributes)
-        attributes.key?(key) && attributes[key] != [] && !attributes[key].nil?
+      def build_assoc?(name, attributes)
+        attributes.key?(name) && attributes[name] != [] && !attributes[name].nil?
       end
 
       def build_assoc_attrs(key, fk, value)

--- a/spec/integration/rom/factory_spec.rb
+++ b/spec/integration/rom/factory_spec.rb
@@ -109,6 +109,12 @@ RSpec.describe ROM::Factory do
           f.association :address
         end
 
+        factories.define(:user_address) do |f|
+          f.association(:user)
+          f.association(:address)
+          f.timestamps
+        end
+
         factories.define(:address) do |f|
           f.full_address "123 Elm St."
         end
@@ -907,6 +913,12 @@ RSpec.describe ROM::Factory do
           f.email "jane@doe.org"
           f.timestamps
           f.association(:addresses, count: 2)
+        end
+
+        factories.define(:user_address) do |f|
+          f.association(:user)
+          f.association(:address)
+          f.timestamps
         end
 
         factories.define(:address) do |f|

--- a/spec/integration/rom/factory_spec.rb
+++ b/spec/integration/rom/factory_spec.rb
@@ -899,6 +899,36 @@ RSpec.describe ROM::Factory do
       end
     end
 
+    context "has_many-through" do
+      before do
+        factories.define(:user) do |f|
+          f.first_name "Jane"
+          f.last_name "Doe"
+          f.email "jane@doe.org"
+          f.timestamps
+          f.association(:addresses, count: 2)
+        end
+
+        factories.define(:address) do |f|
+          f.sequence(:full_address) { |n| "Address #{n}" }
+        end
+      end
+
+      it "creates associated records" do
+        user = factories[:user]
+
+        expect(user.addresses.count).to be(2)
+
+        a1, a2 = user.addresses
+
+        expect(a1.user_id).to be(user.id)
+        expect(a1.full_address).to eql("Address 1")
+
+        expect(a2.user_id).to be(user.id)
+        expect(a2.full_address).to eql("Address 2")
+      end
+    end
+
     context "belongs_to" do
       before do
         factories.define(:user) do |f|

--- a/spec/integration/rom/factory_spec.rb
+++ b/spec/integration/rom/factory_spec.rb
@@ -1146,6 +1146,13 @@ RSpec.describe ROM::Factory do
         expect(rom.relations[:tasks].count).to be(0)
       end
 
+      it "respects FK" do
+        task = factories.structs[:task, user_id: 312]
+
+        expect(task.user_id).to be(312)
+        expect(task.user.id).to be(312)
+      end
+
       it "raises UnknownFactoryAttributes when unknown attributes are used" do
         expect { factories.structs[:user, name: "Joe"] }
           .to raise_error(ROM::Factory::UnknownFactoryAttributes, /name/)

--- a/spec/integration/rom/factory_spec.rb
+++ b/spec/integration/rom/factory_spec.rb
@@ -107,6 +107,12 @@ RSpec.describe ROM::Factory do
 
         expect(task.user).to be_nil
       end
+
+      it "creates the associated record with provided attributes" do
+        task = factories[:task, user: {first_name: "Jane"}]
+
+        expect(task.user.first_name).to eql("Jane")
+      end
     end
 
     context "one-to-one-through" do

--- a/spec/integration/rom/factory_spec.rb
+++ b/spec/integration/rom/factory_spec.rb
@@ -54,6 +54,9 @@ RSpec.describe ROM::Factory do
         end
 
         factories.define(:user) do |f|
+          f.first_name "Jane"
+          f.last_name "Doe"
+          f.email "jane@doe.org"
           f.timestamps
           f.association(:tasks, count: 2)
         end
@@ -67,6 +70,18 @@ RSpec.describe ROM::Factory do
         expect(relations[:users].count).to be_zero
         expect(user_with_tasks.tasks).to all(respond_to(:title, :user_id))
         expect(user_with_tasks.tasks).to all(have_attributes(user_id: user_with_tasks.id))
+      end
+
+      it "sets a value explicitly" do
+        user = factories.structs[:user, tasks: []]
+
+        expect(user.tasks).to be_empty
+      end
+
+      it "sets a value explicitly when persisting" do
+        user = factories[:user, tasks: []]
+
+        expect(user.tasks).to be_empty
       end
 
       it "does not create records when building child" do
@@ -111,13 +126,13 @@ RSpec.describe ROM::Factory do
         it "does not build associated struct if it's set to nil explicitly" do
           task = factories.structs[:task, user: nil]
 
-          expect(task.user).to be_nil
+          expect(task.user).to be(nil)
         end
 
         it "does not persist associated struct if it's set to nil explicitly" do
           task = factories[:task, user: nil]
 
-          expect(task.user).to be_nil
+          expect(task.user).to be(nil)
         end
 
         it "creates the associated record with provided attributes" do

--- a/spec/integration/rom/factory_spec.rb
+++ b/spec/integration/rom/factory_spec.rb
@@ -90,11 +90,22 @@ RSpec.describe ROM::Factory do
           f.association(:user)
         end
 
-        factories.define(:user, &:timestamps)
+        factories.define(:user) do |f|
+          f.first_name "Jane"
+          f.last_name "Doe"
+          f.email "janjiss@gmail.com"
+          f.timestamps
+        end
       end
 
       it "does not pass provided attributes into associations" do
         expect { factories.structs[:task, title: "Bar"] }.not_to raise_error
+      end
+
+      it "does not build associated struct if it's set to nil explicitly" do
+        task = factories[:task, user: nil]
+
+        expect(task.user).to be_nil
       end
     end
 

--- a/spec/integration/rom/factory_spec.rb
+++ b/spec/integration/rom/factory_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe ROM::Factory do
       end
 
       context "when persisting" do
-        it "creates the correct records when the is no pre-existing entity" do
+        it "creates the correct records when there's no pre-existing entity" do
           user = factories[:user]
 
           expect(user.address).to have_attributes(full_address: "123 Elm St.")
@@ -137,8 +137,6 @@ RSpec.describe ROM::Factory do
 
       context "when building a struct" do
         it "persists the relation properly with pre-existing assoc record" do
-          skip "TODO: This does not work, cannot figure out why"
-
           address = factories.structs[:address]
           user = factories.structs[:user, address: address]
 
@@ -146,8 +144,6 @@ RSpec.describe ROM::Factory do
         end
 
         it "persists the relation properly without pre-existing assoc record" do
-          skip "TODO: This does not work, cannot figure out why"
-
           user = factories.structs[:user]
 
           expect(user.address).to have_attributes(full_address: "123 Elm St.")

--- a/spec/integration/rom/factory_spec.rb
+++ b/spec/integration/rom/factory_spec.rb
@@ -95,11 +95,16 @@ RSpec.describe ROM::Factory do
           f.last_name "Doe"
           f.email "janjiss@gmail.com"
           f.timestamps
+
+          f.association(:tasks)
         end
       end
 
-      it "does not pass provided attributes into associations" do
-        expect { factories.structs[:task, title: "Bar"] }.not_to raise_error
+      it "creates a struct with associated parent" do
+        task = factories.structs[:task, title: "Bar"]
+
+        expect(task.title).to eql("Bar")
+        expect(task.user.first_name).to eql("Jane")
       end
 
       it "does not build associated struct if it's set to nil explicitly" do
@@ -109,9 +114,9 @@ RSpec.describe ROM::Factory do
       end
 
       it "creates the associated record with provided attributes" do
-        task = factories[:task, user: {first_name: "Jane"}]
+        task = factories[:task, user: {first_name: "John"}]
 
-        expect(task.user.first_name).to eql("Jane")
+        expect(task.user.first_name).to eql("John")
       end
     end
 

--- a/spec/integration/rom/factory_spec.rb
+++ b/spec/integration/rom/factory_spec.rb
@@ -184,6 +184,22 @@ RSpec.describe ROM::Factory do
           expect(task.author.first_name).to eql("John")
         end
       end
+
+      context "with a self-ref association" do
+        before do
+          factories.define(:task) do |f|
+            f.title { "A Task" }
+            f.association(:parent)
+          end
+        end
+
+        it "creates the associated record with provided attributes" do
+          task = factories[:task, title: "Foo", parent: {title: "Bar"}]
+
+          expect(task.title).to eql("Foo")
+          expect(task.parent.title).to eql("Bar")
+        end
+      end
     end
 
     context "one-to-one-through" do

--- a/spec/integration/rom/factory_spec.rb
+++ b/spec/integration/rom/factory_spec.rb
@@ -976,68 +976,128 @@ RSpec.describe ROM::Factory do
     end
 
     context "has_many" do
-      before do
-        factories.define(:user) do |f|
-          f.first_name "Jane"
-          f.last_name "Doe"
-          f.email "jane@doe.org"
-          f.timestamps
-          f.association(:tasks, count: 2)
+      context "when count is > 0" do
+        before do
+          factories.define(:user) do |f|
+            f.first_name "Jane"
+            f.last_name "Doe"
+            f.email "jane@doe.org"
+            f.timestamps
+            f.association(:tasks, count: 2)
+          end
+
+          factories.define(:task) do |f|
+            f.sequence(:title) { |n| "Task #{n}" }
+          end
         end
 
-        factories.define(:task) do |f|
-          f.sequence(:title) { |n| "Task #{n}" }
+        it "creates associated records" do
+          user = factories[:user]
+
+          expect(user.tasks.count).to be(2)
+
+          t1, t2 = user.tasks
+
+          expect(t1.user_id).to be(user.id)
+          expect(t1.title).to eql("Task 1")
+
+          expect(t2.user_id).to be(user.id)
+          expect(t2.title).to eql("Task 2")
         end
       end
 
-      it "creates associated records" do
-        user = factories[:user]
+      context "when count is 0" do
+        before do
+          factories.define(:user) do |f|
+            f.first_name "Jane"
+            f.last_name "Doe"
+            f.email "jane@doe.org"
+            f.timestamps
+            f.association(:tasks, count: 0)
+          end
 
-        expect(user.tasks.count).to be(2)
+          factories.define(:task) do |f|
+            f.sequence(:title) { |n| "Task #{n}" }
+          end
+        end
 
-        t1, t2 = user.tasks
+        it "doesn't build associated records" do
+          user = factories.structs[:user]
 
-        expect(t1.user_id).to be(user.id)
-        expect(t1.title).to eql("Task 1")
+          expect(user.tasks).to be_empty
+        end
 
-        expect(t2.user_id).to be(user.id)
-        expect(t2.title).to eql("Task 2")
+        it "doesn't create associated records" do
+          user = factories[:user]
+
+          expect(user.tasks).to be_empty
+        end
       end
     end
 
     context "has_many-through" do
-      before do
-        factories.define(:user) do |f|
-          f.first_name "Jane"
-          f.last_name "Doe"
-          f.email "jane@doe.org"
-          f.timestamps
-          f.association(:addresses, count: 2)
+      context "when count is > 0" do
+        before do
+          factories.define(:user) do |f|
+            f.first_name "Jane"
+            f.last_name "Doe"
+            f.email "jane@doe.org"
+            f.timestamps
+            f.association(:addresses, count: 2)
+          end
+
+          factories.define(:user_address) do |f|
+            f.association(:user)
+            f.association(:address)
+            f.timestamps
+          end
+
+          factories.define(:address) do |f|
+            f.sequence(:full_address) { |n| "Address #{n}" }
+          end
         end
 
-        factories.define(:user_address) do |f|
-          f.association(:user)
-          f.association(:address)
-          f.timestamps
-        end
+        it "creates associated records" do
+          user = factories[:user]
 
-        factories.define(:address) do |f|
-          f.sequence(:full_address) { |n| "Address #{n}" }
+          expect(user.addresses.count).to be(2)
+
+          a1, a2 = user.addresses
+
+          expect(a1.user_id).to be(user.id)
+          expect(a1.full_address).to eql("Address 1")
+
+          expect(a2.user_id).to be(user.id)
+          expect(a2.full_address).to eql("Address 2")
         end
       end
 
-      it "creates associated records" do
-        user = factories[:user]
+      context "when count is 0" do
+        before do
+          factories.define(:user) do |f|
+            f.first_name "Jane"
+            f.last_name "Doe"
+            f.email "jane@doe.org"
+            f.timestamps
+            f.association(:addresses, count: 0)
+          end
 
-        expect(user.addresses.count).to be(2)
+          factories.define(:address) do |f|
+            f.sequence(:full_address) { |n| "Address #{n}" }
+          end
+        end
 
-        a1, a2 = user.addresses
+        it "doesn't build associated records" do
+          user = factories.structs[:user]
 
-        expect(a1.user_id).to be(user.id)
-        expect(a1.full_address).to eql("Address 1")
+          expect(user.addresses).to be_empty
+        end
 
-        expect(a2.user_id).to be(user.id)
-        expect(a2.full_address).to eql("Address 2")
+        it "doesn't create associated records" do
+          user = factories[:user]
+
+          expect(user.addresses).to be_empty
+        end
       end
     end
 

--- a/spec/shared/relations.rb
+++ b/spec/shared/relations.rb
@@ -44,6 +44,7 @@ RSpec.shared_context "relations" do
       schema(infer: true) do
         associations do
           belongs_to :user
+          belongs_to :user, as: :author
         end
       end
     end

--- a/spec/shared/relations.rb
+++ b/spec/shared/relations.rb
@@ -19,6 +19,7 @@ RSpec.shared_context "relations" do
     conn.create_table?(:tasks) do
       primary_key :id
       foreign_key :user_id, :users
+      foreign_key :task_id, :tasks, null: true
       column :title, String, null: false
     end
 
@@ -45,6 +46,7 @@ RSpec.shared_context "relations" do
         associations do
           belongs_to :user
           belongs_to :user, as: :author
+          belongs_to :task, as: :parent
         end
       end
     end

--- a/spec/shared/relations.rb
+++ b/spec/shared/relations.rb
@@ -31,6 +31,8 @@ RSpec.shared_context "relations" do
       primary_key :id
       foreign_key :user_id, :users, on_delete: :cascade
       foreign_key :address_id, :addresses, on_delete: :cascade
+      column :created_at, Time, null: false
+      column :updated_at, Time, null: false
     end
 
     conn.create_table?(:key_values) do

--- a/spec/shared/relations.rb
+++ b/spec/shared/relations.rb
@@ -52,6 +52,7 @@ RSpec.shared_context "relations" do
           has_many :tasks
           has_one :user_addresses
           has_one :address, through: :user_addresses
+          has_many :addresses, through: :user_addresses
         end
       end
     end
@@ -61,6 +62,7 @@ RSpec.shared_context "relations" do
         associations do
           has_one :user_addresses
           has_one :user, through: :user_addresses
+          has_one :users, through: :user_addresses
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,13 +5,8 @@ require_relative "support/coverage"
 require "pathname"
 SPEC_ROOT = root = Pathname(__FILE__).dirname
 
-begin
-  require "pry-byebug"
-rescue LoadError
-  require "pry"
-end
-
 require "rom-factory"
+require "byebug"
 require "rspec"
 
 Dir[root.join("support/*.rb").to_s].sort.each do |f|


### PR DESCRIPTION
This adds support for building associated structs in case of `ManyToMany` and `OneToOneThrough` association types, where intermediate join tables are involved. It works with persistable and in-memory structs.

```ruby
factories.define(:user) do |f|
  f.first_name { fake(:name, :first_name) }
  f.last_name { fake(:name, :last_name) }
  f.email { fake(:internet, :email) }
  f.timestamps

  f.association :address
end

factories.define(:user_address) do |f|
  f.association(:user)
  f.association(:address)
  f.timestamps
end

factories.define(:address) do |f|
  f.full_address { fake(:address, :full_address) }
end

# Persisted struct
factories[:user]
# #<ROM::Struct::User id=2 last_name="Leuschke" first_name="Don" alias=nil email="hyman.halvorson@jerde-dach.example" created_at=2023-11-24 10:19:25.693242 +0000 updated_at=2023-11-24 10:19:25.693246 +0000 age=nil type=nil address=#<ROM::Struct::Address id=2 full_address="44090 Patrina Vista, Barrowsburgh, SC 87402" user_id=2>>

# In-memory struct works too
factories.structs[:user]
#<ROM::Struct::User id=1 last_name="Zieme" first_name="Mallory" alias=nil email="lu_nolan@hermiston-hansen.example" created_at=2023-11-24 10:20:05.920642677 +0000 updated_at=2023-11-24 10:20:05.920648427 +0000 age=nil type=nil address=#<ROM::Struct::Address id=1 full_address="Suite 376 7225 Ortiz Centers, East Desmondland, MT 16834-2493" user_id=1>>
```